### PR TITLE
[resolves #44] Add camel rest integration

### DIFF
--- a/examples/camel-rest/pom.xml
+++ b/examples/camel-rest/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Wildfly Camel :: Example :: Camel REST
+  %%
+  Copyright (C) 2013 - 2014 RedHat
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.camel</groupId>
+        <artifactId>wildfly-camel-example</artifactId>
+        <version>1.0.0.CR3-SNAPSHOT</version>
+    </parent>
+
+    <name>Wildfly Camel :: Example :: Camel REST</name>
+
+    <artifactId>example-camel-rest</artifactId>
+	<packaging>war</packaging>
+	
+	<dependencies>
+	
+		<!-- Provided -->
+		<dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-cdi</artifactId>
+	        <scope>provided</scope>
+        </dependency>
+		<dependency>
+		    <groupId>javax.enterprise</groupId>
+		    <artifactId>cdi-api</artifactId>
+		  <scope>provided</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+		  <scope>provided</scope>
+        </dependency>
+	    <dependency>
+	        <groupId>org.jboss.spec.javax.servlet</groupId>
+	        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+	        <scope>provided</scope>
+	    </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+	    
+        <!-- Test Scope -->
+		<dependency>
+	        <groupId>org.wildfly.camel</groupId>
+    		<artifactId>example-camel-common</artifactId>
+	        <version>${project.version}</version>
+	        <scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-arquillian-container-remote</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+	</dependencies>
+
+	<!-- Build -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>wildfly-deploy</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+	<!-- Profiles -->
+	<profiles>
+		<profile>
+			<id>ts.all</id>
+			<activation>
+				<property>
+					<name>ts.all</name>
+				</property>
+			</activation>
+		    <properties>
+		        <jboss.home>${basedir}/../target/wildfly-${version.wildfly}</jboss.home>
+		    </properties>
+		</profile>
+	</profiles>
+</project>

--- a/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/GreetingService.java
+++ b/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/GreetingService.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * Wildfly Camel :: Example :: Camel REST
+ * %%
+ * Copyright (C) 2013 - 2014 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wildfly.camel.examples.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/greet")
+public interface GreetingService {
+    @GET
+    @Path("/hello/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response sayHello(@PathParam("name") String name);
+}

--- a/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/GreetingServiceImpl.java
+++ b/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/GreetingServiceImpl.java
@@ -1,0 +1,57 @@
+/*
+ * #%L
+ * Wildfly Camel :: Example :: Camel REST
+ * %%
+ * Copyright (C) 2013 - 2014 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wildfly.camel.examples.rest;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.cdi.ContextName;
+import org.apache.camel.component.bean.ProxyHelper;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/greet")
+public class GreetingServiceImpl {
+
+    @Inject
+    @ContextName("system-context-1")
+    private CamelContext context;
+
+    private GreetingService greetingServiceProxy;
+
+    @PostConstruct
+    public void initServiceProxy() throws Exception {
+        Endpoint endpoint = context.getEndpoint("direct:start");
+        greetingServiceProxy = ProxyHelper.createProxy(endpoint, GreetingService.class);
+    }
+
+    @GET
+    @Path("/hello/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response sayHello(@PathParam("name") String name) {
+        return greetingServiceProxy.sayHello(name);
+    }
+}

--- a/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/RestApplication.java
+++ b/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/RestApplication.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * Wildfly Camel :: Example :: Camel REST
+ * %%
+ * Copyright (C) 2013 - 2014 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wildfly.camel.examples.rest;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+import java.util.HashSet;
+import java.util.Set;
+
+@ApplicationPath("/rest")
+public class RestApplication extends Application {
+    @Override
+    public Set<Class<?>> getClasses() {
+        final Set<Class<?>> classes = new HashSet<>();
+        classes.add(GreetingServiceImpl.class);
+        return classes;
+    }
+}

--- a/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/RestRouteBuilder.java
+++ b/examples/camel-rest/src/main/java/org/wildfly/camel/examples/rest/RestRouteBuilder.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * Wildfly Camel :: Example :: Camel REST
+ * %%
+ * Copyright (C) 2013 - 2014 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wildfly.camel.examples.rest;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.cdi.ContextName;
+import org.apache.camel.component.bean.BeanInvocation;
+
+import javax.ejb.Startup;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.core.Response;
+
+@Startup
+@ApplicationScoped
+@ContextName("rest-context")
+public class RestRouteBuilder extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("direct:start")
+            .to("log:input?showAll=true")
+            .process(new Processor() {
+                @Override
+                public void process(Exchange exchange) throws Exception {
+                    BeanInvocation beanInvocation = exchange.getIn().getBody(BeanInvocation.class);
+                    String name = (String) beanInvocation.getArgs()[0];
+                    exchange.getOut().setBody(Response.ok().entity("Hello " + name).build());
+                }
+            });
+    }
+}

--- a/examples/camel-rest/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/camel-rest/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Wildfly Camel :: Example :: Camel REST
+  %%
+  Copyright (C) 2013 - 2014 RedHat
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<!-- Marker file indicating CDI should be enabled -->
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd"/>

--- a/examples/camel-rest/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/examples/camel-rest/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Wildfly Camel :: Example :: Camel REST
+  %%
+  Copyright (C) 2013 - 2014 RedHat
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<jboss-web>
+    <context-root>example-camel-rest</context-root>
+</jboss-web>

--- a/examples/camel-rest/src/test/java/org/wildfly/camel/examples/rest/RestIntegrationTest.java
+++ b/examples/camel-rest/src/test/java/org/wildfly/camel/examples/rest/RestIntegrationTest.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * Wildfly Camel :: Example :: Camel REST
+ * %%
+ * Copyright (C) 2013 - 2014 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wildfly.camel.examples.rest;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.camel.examples.HttpRequest;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.TimeUnit;
+
+
+@RunAsClient
+@RunWith(Arquillian.class)
+public class RestIntegrationTest {
+
+    public static final String REST_PATH = "/example-camel-rest/rest/greet/hello/";
+
+    @Test
+    public void testRestRoute() throws Exception {
+        String res = HttpRequest.get(getEndpointAddress(REST_PATH + "Kermit"), 10, TimeUnit.SECONDS);
+        Assert.assertEquals("Hello Kermit", res.trim());
+    }
+
+    private String getEndpointAddress(String restPath) throws MalformedURLException {
+        return "http://localhost:8080" + restPath;
+    }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -41,6 +41,7 @@
 		<module>camel-jpa</module>
         <module>camel-cxf-soap</module>
         <module>camel-activemq</module>
+        <module>camel-rest</module>
 	</modules>
 
     <!-- Properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <version.jboss.shrinkwrap.resolver>2.1.1</version.jboss.shrinkwrap.resolver>
         <version.jboss.spec.javax.annotation>1.0.0.Final</version.jboss.spec.javax.annotation>
         <version.jboss.spec.javax.ejb>1.0.0.Final</version.jboss.spec.javax.ejb>
+        <version.jboss.spec.javax.ws.rs>1.0.0.Final</version.jboss.spec.javax.ws.rs>
         <version.jboss.spec.javax.jms>1.0.0.Final</version.jboss.spec.javax.jms>
         <version.jboss.spec.javax.servlet>1.0.0.Final</version.jboss.spec.javax.servlet>
         <version.junit>4.11</version.junit>
@@ -401,6 +402,11 @@
                 <groupId>org.jboss.spec.javax.servlet</groupId>
                 <artifactId>jboss-servlet-api_3.1_spec</artifactId>
                 <version>${version.jboss.spec.javax.servlet}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
+                <version>${version.jboss.spec.javax.ws.rs}</version>
             </dependency>
 
             <!-- JUnit -->


### PR DESCRIPTION
@tdiesler What do you make of this?

Not using CXF given the issues documented in #61. Instead it uses the [camel-proxy](http://camel.apache.org/using-camelproxy.html) to hook into a standard JAX-RS service.
