### PR TITLE
Fixes #199 Make set of wired camel components configurable

### DIFF
--- a/itests/standalone/src/test/java/org/wildfly/camel/test/CustomComponentsTest.java
+++ b/itests/standalone/src/test/java/org/wildfly/camel/test/CustomComponentsTest.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * Wildfly Camel :: Testsuite
+ * %%
+ * Copyright (C) 2013 - 2014 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.wildfly.camel.test;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.ResolveEndpointFailedException;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.camel.test.smoke.subA.HelloBean;
+import org.wildfly.extension.camel.CamelConstants;
+import org.wildfly.extension.camel.CamelContextRegistry;
+
+/**
+ * Verify that a deployment with a META-INF/jboss-camel-components.properties file
+ * only has the specified components on the classpath.
+ */
+@RunWith(Arquillian.class)
+public class CustomComponentsTest {
+
+    @Deployment
+    public static JavaArchive deployment() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "no-mqtt-tests");
+        archive.addAsResource("jboss-camel-components.properties", "META-INF/jboss-camel-components.properties");
+        return archive;
+    }
+
+    @Test
+    public void testMQTTComponentDoesNotLoad() throws Exception {
+        CamelContext camelctx = new DefaultCamelContext();
+        try {
+            camelctx.getEndpoint("mqtt://dummy");
+            Assert.fail("Expected a ResolveEndpointFailedException");
+        } catch (ResolveEndpointFailedException e) {
+        }
+    }
+
+    @Test
+    public void testFtpComponnentLoads() throws Exception {
+        CamelContext camelctx = new DefaultCamelContext();
+        Endpoint endpoint = camelctx.getEndpoint("ftp://localhost/foo");
+        Assert.assertNotNull(endpoint);
+        Assert.assertEquals(endpoint.getClass().getName(), "org.apache.camel.component.file.remote.FtpEndpoint");
+        camelctx.stop();
+    }
+
+}

--- a/itests/standalone/src/test/resources/jboss-camel-components.properties
+++ b/itests/standalone/src/test/resources/jboss-camel-components.properties
@@ -1,0 +1,6 @@
+#
+# Lets only include the ftp component.
+#
+
+org.apache.camel.component.ftp
+

--- a/subsystem/src/main/java/org/wildfly/extension/camel/CamelConstants.java
+++ b/subsystem/src/main/java/org/wildfly/extension/camel/CamelConstants.java
@@ -48,6 +48,9 @@ public interface CamelConstants {
     String CAMEL_CONTEXT_FILE_SUFFIX = "-camel-context.xml";
     String CAMEL_CONTEXT_FILE_NAME = "META-INF/jboss-camel-context.xml";
 
+    /** This file hold the components to use. */
+    String CAMEL_COMPONENTS_FILE_NAME = "META-INF/jboss-camel-components.properties";
+
     /** The deployment names for repository content deployments */
     String REPOSITORY_CONTENT_FILE_SUFFIX = "-repository-content.xml";
     String REPOSITORY_CONTENT_FILE_NAME = "META-INF/jboss-repository-content.xml";


### PR DESCRIPTION
If a META-INF/jboss-camel-components.properties file is defined in the deployment, then it will only add those the modules listed as keys as dependencies to the deployment unit.