### PR TITLE
[relates #182] Configure hawtio.rolePrincipalClasses in addition to default value from hawtio-wildfly

### DIFF
--- a/itests/distro/etc/wildfly/standalone/configuration/standalone-camel-examples.xml
+++ b/itests/distro/etc/wildfly/standalone/configuration/standalone-camel-examples.xml
@@ -55,6 +55,7 @@
         <property name="hawtio.offline" value="true" />
         <property name="hawtio.realm" value="hawtio-domain" />
         <property name="hawtio.role" value="admin" />
+        <property name="hawtio.rolePrincipalClasses" value="org.jboss.security.SimplePrincipal" />
     </system-properties>
 
     <management>

--- a/patch/etc/wildfly/standalone/configuration/standalone-camel.xml
+++ b/patch/etc/wildfly/standalone/configuration/standalone-camel.xml
@@ -55,6 +55,7 @@
         <property name="hawtio.offline" value="true" />
         <property name="hawtio.realm" value="hawtio-domain" />
         <property name="hawtio.role" value="admin" />
+        <property name="hawtio.rolePrincipalClasses" value="org.jboss.security.SimplePrincipal" />
     </system-properties>
 
     <management>


### PR DESCRIPTION
This fix configures JAAS principal class inside camel subsystem XML. We no longer depend on what's default env entry inside hawtio-web.

This reverts commit 20a421cafc3757c61b9f39172c6653d5f9c3db53.