### PR TITLE
[resolves #1439] Add support for component google-mail

### DIFF
--- a/catalog/src/main/resources/component.roadmap
+++ b/catalog/src/main/resources/component.roadmap
@@ -58,6 +58,7 @@ ftps
 geocoder
 git
 github
+google-mail         	#1439
 google-pubsub
 hbase
 hdfs2
@@ -182,7 +183,6 @@ flink               	#1430
 ganglia             	#1998
 google-calendar     	#1437
 google-drive        	#1438
-google-mail         	#1439
 grape               	#2001
 grpc                	#1826
 guava-eventbus      	#2002

--- a/docs/guide/components/camel-google-mail.adoc
+++ b/docs/guide/components/camel-google-mail.adoc
@@ -1,0 +1,4 @@
+### camel-google-mail
+
+The https://github.com/apache/camel/blob/camel-{camel-version}/components/camel-google-mail/src/main/docs/google-mail-component.adoc[google-mail,window=_blank] component provides access to http://gmail.com/[Gmail] via
+the https://developers.google.com/gmail/api/v1/reference/[Google Mail Web APIs].

--- a/feature/common/etc/smartics/skipped-modules.xml
+++ b/feature/common/etc/smartics/skipped-modules.xml
@@ -18,7 +18,7 @@
   limitations under the License.
   #L%
   -->
-  
+
 <!--
   This file holds all the module definitions that are generallly skipped.
 -->
@@ -27,11 +27,11 @@
     <module name="ant" skip="true">
         <include artifact=":ant" />
     </module>
-    
+
     <module name="aopalliance" skip="true">
         <include artifact="aopalliance" />
     </module>
-    
+
     <module name="asm.extras" skip="true">
         <include artifact="asm:asm-analysis" />
         <include artifact="asm:asm-commons" />
@@ -46,7 +46,7 @@
     <module name="c3p0" skip="true">
         <include artifact="c3p0:c3p0" />
     </module>
-    
+
     <module name="cglib" skip="true">
         <include artifact=":org.apache.servicemix.bundles.cglib" />
     </module>
@@ -100,6 +100,10 @@
         <include artifact="com.google.inject.extensions:guice-servlet"/>
     </module>
 
+    <module name="com.google.oauth-client.google-oauth-client-jetty" skip="true">
+        <include artifact="com.google.oauth-client:google-oauth-client-jetty"/>
+    </module>
+
     <module name="com.ibm.jbatch.tck" skip="true">
         <include artifact="com.ibm.jbatch:com.ibm.jbatch-tck-spi" />
     </module>
@@ -107,15 +111,15 @@
     <module name="com.headius" skip="true">
         <include artifact="com.headius:(.*)" />
     </module>
-    
+
     <module name="com.jcraft.jzlib" skip="true">
         <include artifact="com.jcraft:jzlib" />
     </module>
-    
+
     <module name="com.martiansoftware" skip="true">
         <include artifact="com.martiansoftware:nailgun-server" />
     </module>
-    
+
     <module name="com.sun.codemodel" skip="true">
         <include artifact="com.sun.codemodel:codemodel" />
     </module>
@@ -131,7 +135,7 @@
     <module name="com.sun.ldapbp" skip="true">
         <include artifact="com.sun:ldapbp" />
     </module>
-    
+
     <module name="com.sun.mail" skip="true">
         <include artifact="com.sun.mail:javax.mail" />
     </module>
@@ -139,7 +143,7 @@
     <module name="com.sun.tools" skip="true">
         <include artifact="com.sun:tools" />
     </module>
-    
+
     <module name="com.sun.xml.bind.jaxb.xjc" skip="true">
         <include artifact="com.sun.xml.bind:jaxb-xjc" />
     </module>
@@ -187,7 +191,7 @@
     <module name="jline" skip="true">
         <include artifact=":jline" />
     </module>
-    
+
     <module name="junit" skip="true">
         <include artifact=":junit" />
     </module>
@@ -195,7 +199,7 @@
     <module name="net.java.dev.jna" skip="true">
         <include artifact="net.java.dev.jna:" />
     </module>
-    
+
     <module name="net.jcip" skip="true">
         <include artifact="net.jcip:jcip-annotations" />
     </module>
@@ -223,7 +227,7 @@
     <module name="org.apache.camel.apt" skip="true">
         <include artifact="org.apache.camel:apt" />
     </module>
-    
+
     <module name="org.apache.camel.blueprint" skip="true">
         <include artifact="org.apache.camel:camel-blueprint" />
     </module>
@@ -255,19 +259,19 @@
         <include artifact="org.apache.maven:maven-model" />
         <include artifact="org.apache.maven:maven-model-builder" />
     </module>
-    
+
     <module name="org.apache.servicemix.bundles" skip="true">
         <include artifact="org.apache.servicemix.bundles:org.apache.servicemix.bundles.javax-cache-api" />
     </module>
-    
+
     <module name="org.apache.tomcat.embed" skip="true">
         <include artifact="org.apache.tomcat.embed:(.*)" />
     </module>
-    
+
     <module name="org.codehaus.plexus" skip="true">
         <include artifact="org.codehaus.plexus:(.*)" />
     </module>
-    
+
     <module name="org.codehaus.woodstox.core" skip="true">
         <include artifact=":woodstox-core" />
     </module>
@@ -291,7 +295,7 @@
     <module name="org.glassfish.web" skip="true">
         <include artifact="org.glassfish.web:javax.el" />
     </module>
-    
+
     <module name="org.infinispan.cdi" skip="true">
         <include artifact="org.infinispan:infinispan-cdi-common" />
         <include artifact="org.infinispan:infinispan-cdi-embedded" />
@@ -300,15 +304,15 @@
     <module name="org.jasypt" skip="true">
         <include artifact="org.jasypt:jasypt" />
     </module>
-    
+
     <module name="org.jboss.logging.processor" skip="true">
         <include artifact="org.jboss.logging:jboss-logging-processor" />
     </module>
-    
+
     <module name="org.jboss.marshalling.osgi" skip="true">
         <include artifact="org.jboss.marshalling:jboss-marshalling-osgi" />
     </module>
-    
+
     <module name="org.jboss.interceptor" skip="true">
         <include artifact="org.jboss.interceptor:jboss-interceptor-core" />
         <include artifact="org.jboss.interceptor:jboss-interceptor-spi" />
@@ -318,15 +322,15 @@
     <module name="org.joda.convert" skip="true">
         <include artifact=":joda-convert" />
     </module>
-    
+
     <module name="org.json4s" skip="true">
         <include artifact="org.json4s:json4s-(.*)" />
     </module>
-    
+
     <module name="org.jboss.shrinkwrap" skip="true">
         <include artifact="org.jboss.shrinkwrap:(.*)" />
     </module>
-    
+
     <module name="org.jctools" skip="true">
         <include artifact="org.jctools:(.*)" />
     </module>
@@ -363,7 +367,7 @@
     <module name="org.ops4j" skip="true">
         <include artifact="org.ops4j.base:(.*)" />
     </module>
-    
+
     <module name="org.osgi.compendium" skip="true">
         <include artifact="org.osgi:org.osgi.compendium" />
     </module>
@@ -394,7 +398,7 @@
         <include artifact=":spring-ldap-ldif-core" />
         <include artifact=":spring-ldap-odm" />
     </module>
-    
+
     <module name="software.amazon.ion.ion-java" skip="true">
         <include artifact="software.amazon.ion:ion-java" />
     </module>
@@ -402,5 +406,5 @@
     <module name="xml-apis" skip="true">
         <include artifact=":xml-apis-ext" />
     </module>
-    
+
 </modules>

--- a/feature/modulesB/etc/managed/wildfly/modules/system/layers/fuse/org/apache/camel/component/main/module.xml
+++ b/feature/modulesB/etc/managed/wildfly/modules/system/layers/fuse/org/apache/camel/component/main/module.xml
@@ -75,6 +75,7 @@
         <module name="org.apache.camel.component.geocoder" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.git" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.github" export="true" services="export" optional="true" />
+        <module name="org.apache.camel.component.google.mail" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.google.pubsub" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.groovy" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.gson" export="true" services="export" optional="true" />

--- a/feature/modulesB/etc/smartics/camel-modules.xml
+++ b/feature/modulesB/etc/smartics/camel-modules.xml
@@ -786,13 +786,31 @@
         </exports>
     </module>
 
+    <module name="org.apache.camel.component.google.mail">
+        <include artifact="org.apache.camel:camel-google-mail" />
+        <include artifact="com.google.apis:google-api-services-gmail" />
+        <apply-to-dependencies skip="true">
+            <include module="com.google.oauth-client.google-oauth-client-jetty" />
+            <include module="com.sun.mail" />
+            <include module="org.apache.camel.spi-annotations" />
+            <include module="org.apache.camel.apt" />
+            <include module="org.springframework.boot" />
+        </apply-to-dependencies>
+        <dependencies>
+            <module name="javax.mail.api"/>
+            <module name="org.slf4j"/>
+        </dependencies>
+        <exports>
+            <exclude path="org/apache/camel/component/google/mail/internal" />
+            <exclude path="com/google" />
+            <exclude path="com/google/api" />
+            <exclude path="com/google/api/services" />
+        </exports>
+    </module>
+
     <module name="org.apache.camel.component.google.pubsub">
-        <include artifact="com.google.api-client:google-api-client" />
-        <include artifact="com.google.apis:google-api-services-pubsub" />
-        <include artifact="com.google.http-client:google-http-client" />
-        <include artifact="com.google.http-client:google-http-client-jackson2" />
-        <include artifact="com.google.oauth-client:google-oauth-client" />
         <include artifact="org.apache.camel:camel-google-pubsub" />
+        <include artifact="com.google.apis:google-api-services-pubsub" />
         <apply-to-dependencies skip="true">
             <include module="com.google.android" />
             <include module="com.google.guava.skipped" />
@@ -801,6 +819,8 @@
             <include module="org.springframework.boot" />
         </apply-to-dependencies>
         <dependencies>
+            <module name="com.google.http-client.google-http-client"/>
+            <module name="org.apache.httpcomponents" slot="4.5" />
             <module name="javax.api"/>
             <module name="org.slf4j"/>
         </dependencies>

--- a/feature/modulesB/etc/smartics/other-modules.xml
+++ b/feature/modulesB/etc/smartics/other-modules.xml
@@ -260,6 +260,36 @@
         </dependencies>
     </module>
 
+    <module name="com.google.api-client.google-api-client">
+        <include artifact="com.google.api-client:google-api-client" />
+        <apply-to-dependencies skip="true">
+            <include module="com.google.guava.skipped" />
+        </apply-to-dependencies>
+        <dependencies>
+            <module name="com.google.oauth-client.google-oauth-client" export="true"/>
+        </dependencies>
+    </module>
+
+    <module name="com.google.http-client.google-http-client">
+        <include artifact="com.google.http-client:google-http-client" />
+        <include artifact="com.google.http-client:google-http-client-jackson2" />
+        <apply-to-dependencies skip="true">
+            <include module="com.google.android" />
+            <include module="com.google.code.findbugs" />
+            <include module="com.google.guava.skipped" />
+        </apply-to-dependencies>
+        <dependencies>
+            <module name="javax.api"/>
+        </dependencies>
+    </module>
+
+    <module name="com.google.oauth-client.google-oauth-client">
+        <include artifact="com.google.oauth-client:google-oauth-client" />
+        <apply-to-dependencies skip="true">
+            <include module="com.google.code.findbugs" />
+        </apply-to-dependencies>
+    </module>
+
     <module name="com.google.protobuf">
         <include artifact=":protobuf-java-util" />
         <include artifact=":protobuf-java" />

--- a/feature/modulesB/pom.xml
+++ b/feature/modulesB/pom.xml
@@ -47,7 +47,7 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-analyzers-common</artifactId>
@@ -356,6 +356,10 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-github</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-google-mail</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/feature/pack/src/main/resources/modules/system/layers/fuse/com/google/api-client/google-api-client/main/module.xml
+++ b/feature/pack/src/main/resources/modules/system/layers/fuse/com/google/api-client/google-api-client/main/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="com.google.api-client.google-api-client">
+  <resources>
+    <artifact name="${com.google.api-client:google-api-client}" />
+  </resources>
+  <dependencies>
+    <module name="com.google.oauth-client.google-oauth-client" export="true" />
+    <module name="com.google.http-client.google-http-client" />
+    <module name="org.apache.commons.codec" />
+  </dependencies>
+</module>

--- a/feature/pack/src/main/resources/modules/system/layers/fuse/com/google/http-client/google-http-client/main/module.xml
+++ b/feature/pack/src/main/resources/modules/system/layers/fuse/com/google/http-client/google-http-client/main/module.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="com.google.http-client.google-http-client">
+  <resources>
+    <artifact name="${com.google.http-client:google-http-client}" />
+    <artifact name="${com.google.http-client:google-http-client-jackson2}" />
+  </resources>
+  <dependencies>
+    <module name="javax.api" />
+    <module name="com.fasterxml.jackson.core.jackson-core" />
+    <module name="org.apache.commons.codec" />
+    <module name="org.apache.httpcomponents" slot="4.5" />
+  </dependencies>
+</module>

--- a/feature/pack/src/main/resources/modules/system/layers/fuse/com/google/oauth-client/google-oauth-client/main/module.xml
+++ b/feature/pack/src/main/resources/modules/system/layers/fuse/com/google/oauth-client/google-oauth-client/main/module.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="com.google.oauth-client.google-oauth-client">
+  <resources>
+    <artifact name="${com.google.oauth-client:google-oauth-client}" />
+  </resources>
+  <dependencies>
+    <module name="com.google.http-client.google-http-client" />
+  </dependencies>
+</module>

--- a/feature/pack/src/main/resources/modules/system/layers/fuse/org/apache/camel/component/google/mail/main/module.xml
+++ b/feature/pack/src/main/resources/modules/system/layers/fuse/org/apache/camel/component/google/mail/main/module.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="org.apache.camel.component.google.mail">
+  <resources>
+    <artifact name="${org.apache.camel:camel-google-mail}" />
+    <artifact name="${com.google.apis:google-api-services-gmail}" />
+    <artifact name="${com.google.apis:google-api-services-gmail}" />
+  </resources>
+  <dependencies>
+    <module name="javax.mail.api" />
+    <module name="org.slf4j" />
+    <module name="com.google.api-client.google-api-client" />
+    <module name="com.google.http-client.google-http-client" />
+    <module name="javax.xml.bind.api" />
+    <module name="org.apache.camel.core" />
+  </dependencies>
+  <exports>
+    <exclude path="org/apache/camel/component/google/mail/internal" />
+    <exclude path="com/google" />
+    <exclude path="com/google/api" />
+    <exclude path="com/google/api/services" />
+  </exports>
+</module>

--- a/feature/pack/src/main/resources/modules/system/layers/fuse/org/apache/camel/component/google/pubsub/main/module.xml
+++ b/feature/pack/src/main/resources/modules/system/layers/fuse/org/apache/camel/component/google/pubsub/main/module.xml
@@ -2,20 +2,16 @@
 <module xmlns="urn:jboss:module:1.1" name="org.apache.camel.component.google.pubsub">
   <resources>
     <artifact name="${org.apache.camel:camel-google-pubsub}" />
-    <artifact name="${com.google.api-client:google-api-client}" />
     <artifact name="${com.google.apis:google-api-services-pubsub}" />
-    <artifact name="${com.google.http-client:google-http-client}" />
-    <artifact name="${com.google.http-client:google-http-client-jackson2}" />
-    <artifact name="${com.google.oauth-client:google-oauth-client}" />
   </resources>
   <dependencies>
+    <module name="com.google.http-client.google-http-client" />
+    <module name="org.apache.httpcomponents" slot="4.5" />
     <module name="javax.api" />
     <module name="org.slf4j" />
-    <module name="com.fasterxml.jackson.core.jackson-core" />
+    <module name="com.google.api-client.google-api-client" />
     <module name="javax.xml.bind.api" />
     <module name="org.apache.camel.core" />
-    <module name="org.apache.commons.codec" />
-    <module name="org.apache.httpcomponents" slot="4.5" />
   </dependencies>
   <exports>
     <include path="com/google/api/services/pubsub**" />

--- a/feature/pack/src/main/resources/modules/system/layers/fuse/org/apache/camel/component/main/module.xml
+++ b/feature/pack/src/main/resources/modules/system/layers/fuse/org/apache/camel/component/main/module.xml
@@ -75,6 +75,7 @@
         <module name="org.apache.camel.component.geocoder" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.git" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.github" export="true" services="export" optional="true" />
+        <module name="org.apache.camel.component.google.mail" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.google.pubsub" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.groovy" export="true" services="export" optional="true" />
         <module name="org.apache.camel.component.gson" export="true" services="export" optional="true" />

--- a/itests/standalone/basic/google-api-testing.adoc
+++ b/itests/standalone/basic/google-api-testing.adoc
@@ -1,0 +1,72 @@
+= Google API Testing
+
+The tests accessing Google API require a Google account, whose credentials cannot be shared with the world in this git repository.
+Those tests are thus skipped unless you set the following environment variables:
+
+[source,shell]
+----
+export GOOGLE_API_APPLICATION_NAME="..."
+export GOOGLE_API_CLIENT_ID="..."
+export GOOGLE_API_CLIENT_SECRET="..."
+export GOOGLE_API_REFRESH_TOKEN="..."
+----
+
+
+== Obtain Google API credentials
+
+=== Red Hatters
+
+There is a Google account called `camel.itest` whose credentials are accessible to Red Hat engineers and to Fusesource Jenkins running internally at Red Hat.
+
+=== Setup from scratch
+
+If you do not have an access to the above credentials, or if you want to start from scratch, here is how:
+
+1. Create a new Google account or take an existing. In what follows, we will re refer to this account as `john-the-tester`.
+
+2. Being logged in to Google as `john-the-tester`, go to
+  https://console.developers.google.com/apis/credentials/consent[Google API Console > Credentials > OAuth consent screen].
+  Fill in some meaningful values and save.
+
+2.1 Switch to https://console.developers.google.com/apis/credentials[Credentials tab]
+
+2.2 Create credentials > OAuth Client ID > Web application.
+
+2.2.1 Fill in the Name and note it for the `GOOGLE_API_APPLICATION_NAME` environment variable.
+
+2.2.2 Add `https://developers.google.com/oauthplayground` to Authorized redirect URIs.
+
+2.2.3 Note the `Client ID` for the `GOOGLE_API_CLIENT_ID` environment variable
+  and `Client secret` for `GOOGLE_API_CLIENT_SECRET`.
+
+2.2.4 Save.
+
+3. Still being logged in to Google as `john-the-tester`, go to https://developers.google.com/oauthplayground/[OAuth 2.0 Playground]
+
+3.1 Click the Gears icon `OAuth 2.0 Configuration` in the top right corner
+
+3.1.1 Make sure `Access type` is `Offline`
+
+3.1.2 Check `Use your own OAuth credentials` and fill in the `Client ID` and `Client secret` you noted in step 2.2.3.
+
+3.1.3 Close the `OAuth 2.0 Configuration` dialog.
+
+3.2 Back in the main OAuth 2.0 Playground pane, on the left in the list of APIs, select `Gmail API v1` > `https://mail.google.com/`
+
+3.3 Click `Authorize APIs`
+
+3.3.1 If Google lets you choose an account, choose the `john-the-tester` account
+
+3.3.2 If Google warns `This app isn't verified`, click `Advanced` and then click `Go to <your_app_name> (unsafe)`
+
+3.3.3 Allow your app to use the selected scope
+
+3.4 Back in the Back in the main OAuth 2.0 Playground pane:
+
+3.4.1 You can ignore the newly created `Authorization code`
+
+3.4.2 Click `Exchange authorization code for tokens`
+
+3.4.3 Previous step brings you to Step 3 of the OAuth 2.0 Playground which is not what we want. Go back to Step 2. of OAuth 2.0 Playground.
+
+3.4.4 Back in the Step 2 of OAuth 2.0 Playground, note the `Refresh token` for the `GOOGLE_API_REFRESH_TOKEN` environment variable.

--- a/itests/standalone/basic/pom.xml
+++ b/itests/standalone/basic/pom.xml
@@ -35,6 +35,7 @@
     <!-- Properties -->
     <properties>
         <server.config>standalone-full.xml</server.config>
+        <org.wildfly.camel.google.api.oauth.properties.path>${basedir}/src/test/resources/google/google-oauth.properties</org.wildfly.camel.google.api.oauth.properties.path>
     </properties>
 
     <!-- Dependencies -->
@@ -188,6 +189,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <org.jboss.remoting-jmx.timeout>300</org.jboss.remoting-jmx.timeout>
+                        <org.wildfly.camel.google.api.oauth.properties.path>${org.wildfly.camel.google.api.oauth.properties.path}</org.wildfly.camel.google.api.oauth.properties.path>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/itests/standalone/basic/src/test/java/org/wildfly/camel/test/google/GoogleApiEnv.java
+++ b/itests/standalone/basic/src/test/java/org/wildfly/camel/test/google/GoogleApiEnv.java
@@ -1,0 +1,33 @@
+package org.wildfly.camel.test.google;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum GoogleApiEnv {
+    GOOGLE_API_APPLICATION_NAME("applicationName"), //
+    GOOGLE_API_CLIENT_ID("clientId"), //
+    GOOGLE_API_CLIENT_SECRET("clientSecret"), //
+    GOOGLE_API_REFRESH_TOKEN("refreshToken");
+    public static Map<String, Object> byConfigPropertyName() {
+        Map<String, Object> result = new HashMap<>();
+        for (GoogleApiEnv googleApiEnv : GoogleApiEnv.values()) {
+            final Object val = System.getenv(googleApiEnv.name());
+            if (val == null || "".equals(val)) {
+                return Collections.emptyMap();
+            }
+            result.put(googleApiEnv.getConfigPropertyName(), val);
+        }
+        return Collections.unmodifiableMap(result);
+    }
+
+    private String configPropertyName;
+
+    private GoogleApiEnv(String configPropertyName) {
+        this.configPropertyName = configPropertyName;
+    }
+
+    public String getConfigPropertyName() {
+        return configPropertyName;
+    }
+}

--- a/itests/standalone/basic/src/test/java/org/wildfly/camel/test/google/mail/GoogleMailIntegrationTest.java
+++ b/itests/standalone/basic/src/test/java/org/wildfly/camel/test/google/mail/GoogleMailIntegrationTest.java
@@ -1,0 +1,505 @@
+/*
+ * #%L
+ * Wildfly Camel :: Testsuite
+ * %%
+ * Copyright (C) 2013 - 2017 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.wildfly.camel.test.google.mail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.google.mail.GoogleMailComponent;
+import org.apache.camel.component.google.mail.GoogleMailConfiguration;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.util.IntrospectionSupport;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.camel.test.google.GoogleApiEnv;
+import org.wildfly.extension.camel.CamelAware;
+
+import com.google.api.services.gmail.model.Label;
+import com.google.api.services.gmail.model.ListLabelsResponse;
+import com.google.api.services.gmail.model.ListMessagesResponse;
+import com.google.api.services.gmail.model.ListThreadsResponse;
+import com.google.api.services.gmail.model.Message;
+import com.google.api.services.gmail.model.Profile;
+
+/**
+ * Read {@code google-api-testing.adoc} in the rood directory of the current Maven module to learn how to set up the
+ * {@code google-oauth.properties} properly.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+@CamelAware
+@RunWith(Arquillian.class)
+public class GoogleMailIntegrationTest {
+    private static final Logger log = Logger.getLogger(GoogleMailIntegrationTest.class);
+    // userid of the currently authenticated user
+    public static final String CURRENT_USERID = "me";
+
+    private static void configure(GoogleMailComponent gMailComponent) throws Exception {
+        final GoogleMailConfiguration config = gMailComponent.getConfiguration();
+        Map<String, Object> map = GoogleApiEnv.byConfigPropertyName();
+        final boolean assumption = map.size() == GoogleApiEnv.values().length;
+        if (!assumption) {
+            final String msg = "Some or all of env vars "+ Arrays.asList(GoogleApiEnv.values()) +" are missing. You may want read google-api-testing.adoc in the rood directory of the current Maven module.";
+            log.warn(msg);
+            Assume.assumeTrue(msg, assumption);
+        }
+        map.entrySet().stream().forEach(en -> {
+            try {
+                IntrospectionSupport.setProperty(config, en.getKey(), en.getValue());
+            } catch (Exception e) {
+                throw new RuntimeException("Could not set " + config.getClass().getSimpleName() + "." + en.getKey(), e);
+            }
+        });
+    }
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, "camel-google-mail-tests.jar").addClass(GoogleApiEnv.class);
+    }
+
+    private static Message createMessage(ProducerTemplate template, String subject)
+            throws MessagingException, IOException {
+
+        Profile profile = template.requestBody("google-mail://users/getProfile?inBody=userId", CURRENT_USERID,
+                Profile.class);
+        Session session = Session.getDefaultInstance(new Properties(), null);
+        MimeMessage mm = new MimeMessage(session);
+        mm.addRecipients(javax.mail.Message.RecipientType.TO, profile.getEmailAddress());
+        mm.setSubject(subject);
+        mm.setContent("Camel rocks!\n" //
+                + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()) + "\n" //
+                + "user: " + System.getProperty("user.name"), "text/plain");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        mm.writeTo(baos);
+        String encodedEmail = Base64.getUrlEncoder().encodeToString(baos.toByteArray());
+        Message message = new Message();
+        message.setRaw(encodedEmail);
+        return message;
+    }
+
+    private static Message createThreadedMessage(String previousThreadId, String subject, ProducerTemplate template)
+            throws MessagingException, IOException {
+        Message message = createMessage(template, subject);
+        if (previousThreadId != null) {
+            message.setThreadId(previousThreadId);
+        }
+
+        Map<String, Object> headers = new HashMap<String, Object>();
+        // parameter type is String
+        headers.put("CamelGoogleMail.userId", CURRENT_USERID);
+        // parameter type is com.google.api.services.gmail.model.Message
+        headers.put("CamelGoogleMail.content", message);
+
+        return template.requestBodyAndHeaders("google-mail://messages/send", null, headers, Message.class);
+    }
+
+    private static Label findLabel(ListLabelsResponse labels, String label) {
+        for (Label l : labels.getLabels()) {
+            if (label.equals(l.getName())) {
+                return l;
+            }
+        }
+        return null;
+    }
+
+    private static boolean idInList(String testEmailId, ListMessagesResponse listOfMessages) {
+        Assert.assertNotNull("list result", listOfMessages);
+        List<Message> messages = listOfMessages.getMessages();
+        if (messages != null) {
+            for (Message m : listOfMessages.getMessages()) {
+                if (testEmailId.equals(m.getId())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void labels() throws Exception {
+
+        CamelContext camelctx = new DefaultCamelContext();
+
+        GoogleMailComponent gMailComponent = camelctx.getComponent("google-mail", GoogleMailComponent.class);
+        configure(gMailComponent);
+
+        camelctx.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                final String pathPrefix = "labels";
+                // test route for create
+                from("direct://CREATE").to("google-mail://" + pathPrefix + "/create");
+
+                // test route for delete
+                from("direct://DELETE").to("google-mail://" + pathPrefix + "/delete");
+
+                // test route for get
+                from("direct://GET").to("google-mail://" + pathPrefix + "/get");
+
+                // test route for list
+                from("direct://LIST").to("google-mail://" + pathPrefix + "/list?inBody=userId");
+
+                // test route for patch
+                from("direct://PATCH").to("google-mail://" + pathPrefix + "/patch");
+
+                // test route for update
+                from("direct://UPDATE").to("google-mail://" + pathPrefix + "/update");
+            }
+        });
+
+        try {
+            camelctx.start();
+
+            ProducerTemplate template = camelctx.createProducerTemplate();
+
+            // using String message body for single parameter "userId"
+            ListLabelsResponse labels = template.requestBody("direct://LIST", CURRENT_USERID, ListLabelsResponse.class);
+
+            final String testLabel = getClass().getSimpleName() + ".labels " + UUID.randomUUID().toString();
+
+            String labelId = null;
+            if (findLabel(labels, testLabel) == null) {
+                Map<String, Object> headers = new HashMap<String, Object>();
+                // parameter type is String
+                headers.put("CamelGoogleMail.userId", CURRENT_USERID);
+                Label label = new Label().setName(testLabel).setMessageListVisibility("show")
+                        .setLabelListVisibility("labelShow");
+                // parameter type is com.google.api.services.gmail.model.Label
+                headers.put("CamelGoogleMail.content", label);
+
+                Label result = template.requestBodyAndHeaders("direct://CREATE", null, headers, Label.class);
+
+                Assert.assertNotNull("create result", result);
+                labelId = result.getId();
+            } else {
+                labelId = findLabel(labels, testLabel).getId();
+            }
+
+            // using String message body for single parameter "userId"
+            labels = template.requestBody("direct://LIST", CURRENT_USERID, ListLabelsResponse.class);
+            Assert.assertTrue(findLabel(labels, testLabel) != null);
+
+            Map<String, Object> headers = new HashMap<String, Object>();
+            // parameter type is String
+            headers.put("CamelGoogleMail.userId", CURRENT_USERID);
+            // parameter type is String
+            headers.put("CamelGoogleMail.id", labelId);
+
+            template.requestBodyAndHeaders("direct://DELETE", null, headers);
+
+            // using String message body for single parameter "userId"
+            labels = template.requestBody("direct://LIST", CURRENT_USERID, ListLabelsResponse.class);
+            Assert.assertTrue(findLabel(labels, testLabel) == null);
+
+        } finally {
+            camelctx.stop();
+        }
+
+    }
+
+    @Test
+    public void messages() throws Exception {
+
+        CamelContext camelctx = new DefaultCamelContext();
+
+        GoogleMailComponent gMailComponent = camelctx.getComponent("google-mail", GoogleMailComponent.class);
+        configure(gMailComponent);
+
+        camelctx.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+
+                final String pathPrefix = "messages";
+
+                // test route for attachments
+                from("direct://ATTACHMENTS").to("google-mail://" + pathPrefix + "/attachments");
+
+                // test route for delete
+                from("direct://DELETE").to("google-mail://" + pathPrefix + "/delete");
+
+                // test route for get
+                from("direct://GET").to("google-mail://" + pathPrefix + "/get");
+
+                // test route for gmailImport
+                from("direct://GMAILIMPORT").to("google-mail://" + pathPrefix + "/gmailImport");
+
+                // test route for gmailImport
+                from("direct://GMAILIMPORT_1").to("google-mail://" + pathPrefix + "/gmailImport");
+
+                // test route for insert
+                from("direct://INSERT").to("google-mail://" + pathPrefix + "/insert");
+
+                // test route for insert
+                from("direct://INSERT_1").to("google-mail://" + pathPrefix + "/insert");
+
+                // test route for list
+                from("direct://LIST").to("google-mail://" + pathPrefix + "/list?inBody=userId");
+
+                // test route for modify
+                from("direct://MODIFY").to("google-mail://" + pathPrefix + "/modify");
+
+                // test route for send
+                from("direct://SEND").to("google-mail://" + pathPrefix + "/send");
+
+                // test route for send
+                from("direct://SEND_1").to("google-mail://" + pathPrefix + "/send");
+
+                // test route for trash
+                from("direct://TRASH").to("google-mail://" + pathPrefix + "/trash");
+
+                // test route for untrash
+                from("direct://UNTRASH").to("google-mail://" + pathPrefix + "/untrash");
+
+            }
+        });
+
+        try {
+            camelctx.start();
+
+            ProducerTemplate template = camelctx.createProducerTemplate();
+            // ==== Send test email ====
+
+            final String subject = getClass().getSimpleName() + ".messages " + UUID.randomUUID().toString();
+
+            Message testEmail = createMessage(template, subject);
+            Map<String, Object> headers = new HashMap<String, Object>();
+            // parameter type is String
+            headers.put("CamelGoogleMail.userId", CURRENT_USERID);
+            // parameter type is com.google.api.services.gmail.model.Message
+            headers.put("CamelGoogleMail.content", testEmail);
+
+            Message result = template.requestBodyAndHeaders("direct://SEND", null, headers, Message.class);
+            Assert.assertNotNull("send result", result);
+            String testEmailId = result.getId();
+
+            // ==== Search for message we just sent ====
+            headers = new HashMap<String, Object>();
+            headers.put("CamelGoogleMail.q", "subject:\"" + subject + "\"");
+            // using String message body for single parameter "userId"
+            ListMessagesResponse listOfMessages = template.requestBody("direct://LIST", CURRENT_USERID,
+                    ListMessagesResponse.class);
+            Assert.assertTrue(idInList(testEmailId, listOfMessages));
+
+            // ===== trash it ====
+            headers = new HashMap<String, Object>();
+            // parameter type is String
+            headers.put("CamelGoogleMail.userId", CURRENT_USERID);
+            // parameter type is String
+            headers.put("CamelGoogleMail.id", testEmailId);
+            template.requestBodyAndHeaders("direct://TRASH", null, headers);
+
+            // ==== Search for message we just trashed ====
+            headers = new HashMap<String, Object>();
+            headers.put("CamelGoogleMail.q", "subject:\"" + subject + "\"");
+            // using String message body for single parameter "userId"
+            listOfMessages = template.requestBody("direct://LIST", CURRENT_USERID, ListMessagesResponse.class);
+            Assert.assertFalse(idInList(testEmailId, listOfMessages));
+
+            // ===== untrash it ====
+            headers = new HashMap<String, Object>();
+            // parameter type is String
+            headers.put("CamelGoogleMail.userId", CURRENT_USERID);
+            // parameter type is String
+            headers.put("CamelGoogleMail.id", testEmailId);
+            template.requestBodyAndHeaders("direct://UNTRASH", null, headers);
+
+            // ==== Search for message we just untrashed ====
+            headers = new HashMap<String, Object>();
+            headers.put("CamelGoogleMail.q", "subject:\"" + subject + "\"");
+            // using String message body for single parameter "userId"
+            listOfMessages = template.requestBody("direct://LIST", CURRENT_USERID, ListMessagesResponse.class);
+            Assert.assertTrue(idInList(testEmailId, listOfMessages));
+
+            // ===== permanently delete it ====
+            headers = new HashMap<String, Object>();
+            // parameter type is String
+            headers.put("CamelGoogleMail.userId", CURRENT_USERID);
+            // parameter type is String
+            headers.put("CamelGoogleMail.id", testEmailId);
+            template.requestBodyAndHeaders("direct://DELETE", null, headers);
+
+            // ==== Search for message we just deleted ====
+            headers = new HashMap<String, Object>();
+            headers.put("CamelGoogleMail.q", "subject:\"" + subject + "\"");
+            // using String message body for single parameter "userId"
+            listOfMessages = template.requestBody("direct://LIST", CURRENT_USERID, ListMessagesResponse.class);
+            Assert.assertFalse(idInList(testEmailId, listOfMessages));
+        } finally {
+            camelctx.stop();
+        }
+    }
+
+    @Test
+    public void profile() throws Exception {
+        CamelContext camelctx = new DefaultCamelContext();
+
+        GoogleMailComponent gMailComponent = camelctx.getComponent("google-mail", GoogleMailComponent.class);
+        configure(gMailComponent);
+
+        camelctx.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                final String pathPrefix = "users";
+                // test route for attachments
+                from("direct://GETPROFILE").to("google-mail://" + pathPrefix + "/getProfile?inBody=userId");
+            }
+        });
+
+        try {
+            camelctx.start();
+
+            ProducerTemplate template = camelctx.createProducerTemplate();
+            // using String message body for single parameter "userId"
+            final Profile result = template.requestBody("direct://GETPROFILE", CURRENT_USERID, Profile.class);
+
+            Assert.assertNotNull("getProfile result", result);
+            Assert.assertNotNull("Should be email address associated with current account", result.getEmailAddress());
+            System.out.println("getProfile: " + result);
+        } finally {
+            camelctx.stop();
+        }
+    }
+
+    @SuppressWarnings("serial")
+    @Test
+    public void threads() throws Exception {
+
+        CamelContext camelctx = new DefaultCamelContext();
+
+        GoogleMailComponent gMailComponent = camelctx.getComponent("google-mail", GoogleMailComponent.class);
+        configure(gMailComponent);
+
+        camelctx.addRoutes(new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                final String pathPrefix = "threads";
+                ;
+                // test route for delete
+                from("direct://DELETE").to("google-mail://" + pathPrefix + "/delete");
+
+                // test route for get
+                from("direct://GET").to("google-mail://" + pathPrefix + "/get");
+
+                // test route for list
+                from("direct://LIST").to("google-mail://" + pathPrefix + "/list?inBody=userId");
+
+                // test route for modify
+                from("direct://MODIFY").to("google-mail://" + pathPrefix + "/modify");
+
+                // test route for trash
+                from("direct://TRASH").to("google-mail://" + pathPrefix + "/trash");
+
+                // test route for untrash
+                from("direct://UNTRASH").to("google-mail://" + pathPrefix + "/untrash");
+
+            }
+        });
+
+        try {
+            camelctx.start();
+
+            final String subject = getClass().getSimpleName() + ".threads " + UUID.randomUUID().toString();
+
+            ProducerTemplate template = camelctx.createProducerTemplate();
+            Message m1 = createThreadedMessage(null, subject, template);
+            final String threadId = m1.getThreadId();
+            createThreadedMessage(threadId, subject, template);
+
+            // using String message body for single parameter "userId"
+            ListThreadsResponse result = template.requestBodyAndHeaders("direct://LIST", CURRENT_USERID,
+                    Collections.singletonMap("CamelGoogleMail.q", "subject:\"" + subject + "\""),
+                    ListThreadsResponse.class);
+
+            Assert.assertNotNull("list result", result);
+            Assert.assertTrue(result.getThreads().size() > 0);
+
+            // ===== trash it ====
+            template.requestBodyAndHeaders("direct://TRASH", null, new HashMap<String, Object>() {
+                {
+                    put("CamelGoogleMail.userId", CURRENT_USERID);
+                    put("CamelGoogleMail.id", threadId);
+                }
+            });
+
+            // ==== Search for message we just trashed ====
+            result = template.requestBodyAndHeaders("direct://LIST", CURRENT_USERID,
+                    Collections.singletonMap("CamelGoogleMail.q", "subject:\"" + subject + "\""),
+                    ListThreadsResponse.class);
+            Assert.assertNotNull("list result", result);
+            Assert.assertTrue(result.getThreads() == null
+                    || result.getThreads().stream().noneMatch(t -> threadId.equals(t.getId())));
+
+            /* For some reason the thread deletion often needs some delay to succeed */
+            int attemptCount = 0;
+            for (;;) {
+                try {
+                    template.requestBodyAndHeaders("direct://DELETE", null, new HashMap<String, Object>() {
+                        {
+                            put("CamelGoogleMail.userId", CURRENT_USERID);
+                            put("CamelGoogleMail.id", threadId);
+                        }
+                    });
+                    break; /* success */
+                } catch (Exception e) {
+                    if (attemptCount >= 5) {
+                        throw e; /* too many attempts */
+                    } else {
+                        /* retry */
+                        try {
+                            Thread.sleep(500);
+                        } catch (InterruptedException e1) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                }
+            }
+
+        } finally {
+            camelctx.stop();
+        }
+
+    }
+}

--- a/itests/standalone/basic/src/test/resources/arquillian.xml
+++ b/itests/standalone/basic/src/test/resources/arquillian.xml
@@ -8,9 +8,9 @@
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,16 +21,16 @@
 
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
-    
+
     <defaultProtocol type="jmx-as7" />
-    
+
     <container qualifier="managed" default="true">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
             <property name="serverConfig">${server.config}</property>
-            <property name="javaVmArguments">${jvmArgs} ${jvmDebugArgs}</property>
+            <property name="javaVmArguments">${jvmArgs} ${jvmDebugArgs} -Dorg.wildfly.camel.google.api.oauth.properties.path=${org.wildfly.camel.google.api.oauth.properties.path}</property>
             <property name="allowConnectingToRunningServer">true</property>
         </configuration>
     </container>
-    
+
 </arquillian>

--- a/itests/standalone/basic/src/test/resources/google/google-oauth.properties
+++ b/itests/standalone/basic/src/test/resources/google/google-oauth.properties
@@ -1,0 +1,25 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# Login properties for Google API
+#
+# You may want to read ../../../../google-api-testing.adoc before editing this file
+#
+clientId=
+clientSecret=
+applicationName=
+refreshToken=

--- a/itests/standalone/extra/src/test/resources/classloading/exported-path-patterns.txt
+++ b/itests/standalone/extra/src/test/resources/classloading/exported-path-patterns.txt
@@ -1,5 +1,5 @@
 [includes]
-	^ca/uhn/hl7v2(.*)    
+	^ca/uhn/hl7v2(.*)
 	^com/amazonaws(.*)
     ^com/bazaarvoice(.*)
 	^com/box(.*)
@@ -9,6 +9,7 @@
 	^com/codahale(.*)
 	^com/github/kristofa/brave(.*)
 	^com/google/api/services/pubsub(.*)
+    ^com/google/api/services/gmail(.*)
     ^com/google/code/geocoder/model(.*)
     ^com/google/gson(.*)
 	^com/google/protobuf(.*)
@@ -100,6 +101,6 @@
 	^zoneinfo/(.*)
 	^META-INF/cxf(.*)
 	^META-INF/services(.*)
-	
+
 [excludes]
 	(.*)/internal

--- a/itests/standalone/extra/src/test/resources/classloading/exported-paths.txt
+++ b/itests/standalone/extra/src/test/resources/classloading/exported-paths.txt
@@ -526,6 +526,8 @@ com/dropbox/core/json
 com/dropbox/core/util
 com/github/kristofa/brave
 com/github/kristofa/brave/scribe
+com/google/api/services/gmail
+com/google/api/services/gmail/model
 com/google/api/services/pubsub
 com/google/api/services/pubsub/model
 com/google/code/geocoder/model
@@ -896,6 +898,7 @@ org/apache/camel/component/github
 org/apache/camel/component/github/consumer
 org/apache/camel/component/github/producer
 org/apache/camel/component/google
+org/apache/camel/component/google/mail
 org/apache/camel/component/google/pubsub
 org/apache/camel/component/google/pubsub/consumer
 org/apache/camel/component/gson

--- a/patch/etc/baseline/module-list.txt
+++ b/patch/etc/baseline/module-list.txt
@@ -24,8 +24,12 @@
 /com/fasterxml/jackson/datatype/joda/main/jackson-datatype-joda-2.7.4.jar
 /com/fasterxml/jackson/module/jsonSchema/main/jackson-module-jsonSchema-2.7.4.jar
 /com/github/generex/main/generex-1.0.1.jar
+/com/google/api-client/google-api-client/main/google-api-client-1.22.0.jar
 /com/google/code/gson/main/gson-2.7.jar
 /com/google/guava/14.0/guava-14.0.1.jar
+/com/google/http-client/google-http-client/main/google-http-client-1.22.0.jar
+/com/google/http-client/google-http-client/main/google-http-client-jackson2-1.22.0.jar
+/com/google/oauth-client/google-oauth-client/main/google-oauth-client-1.22.0.jar
 /com/google/protobuf/2.5.0/protobuf-java-2.5.0.jar
 /com/google/protobuf/main/protobuf-java-3.1.0.jar
 /com/google/protobuf/main/protobuf-java-util-3.1.0.jar
@@ -156,12 +160,10 @@
 /org/apache/camel/component/git/main/org.eclipse.jgit-4.7.0.201704051617-r.jar
 /org/apache/camel/component/github/main/camel-github-2.19.3.jar
 /org/apache/camel/component/github/main/org.eclipse.egit.github.core-2.1.5.jar
+/org/apache/camel/component/google/mail/main/camel-google-mail-2.19.3.jar
+/org/apache/camel/component/google/mail/main/google-api-services-gmail-v1-rev63-1.22.0.jar
 /org/apache/camel/component/google/pubsub/main/camel-google-pubsub-2.19.3.jar
-/org/apache/camel/component/google/pubsub/main/google-api-client-1.22.0.jar
 /org/apache/camel/component/google/pubsub/main/google-api-services-pubsub-v1-rev12-1.22.0.jar
-/org/apache/camel/component/google/pubsub/main/google-http-client-1.22.0.jar
-/org/apache/camel/component/google/pubsub/main/google-http-client-jackson2-1.22.0.jar
-/org/apache/camel/component/google/pubsub/main/google-oauth-client-1.22.0.jar
 /org/apache/camel/component/groovy/main/camel-groovy-2.19.3.jar
 /org/apache/camel/component/gson/main/camel-gson-2.19.3.jar
 /org/apache/camel/component/hbase/main/camel-hbase-2.19.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
        http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,7 +44,7 @@
 
     <!-- Properties -->
     <properties>
-        
+
         <!-- Camel versions -->
         <version.apache.camel>2.19.3</version.apache.camel>
         <version.camel.lucene5>5.5.2</version.camel.lucene5>
@@ -58,7 +58,7 @@
         <version.wildfly.arquillian>1.0.2.Final</version.wildfly.arquillian>
         <version.wildfly.fasterxml.jackson>2.7.4</version.wildfly.fasterxml.jackson>
         <version.wildfly.infinispan>8.2.4.Final</version.wildfly.infinispan>
-        
+
         <!-- Other versions -->
         <version.apache.ds>2.0.0-M21</version.apache.ds>
         <version.apache.ds.codec>1.0.0-M33</version.apache.ds.codec>
@@ -86,7 +86,7 @@
         <version.net.sf.json>2.4</version.net.sf.json>
         <version.osgi>5.0.0</version.osgi>
         <version.redis.embedded>0.6</version.redis.embedded>
-        
+
         <!-- Plugin versions -->
         <version-apache-scr-plugin>1.21.0</version-apache-scr-plugin>
         <version-asciidoctor-maven-plugin>1.5.3</version-asciidoctor-maven-plugin>
@@ -111,7 +111,7 @@
         <version-maven-release-plugin>2.5</version-maven-release-plugin>
         <version-maven-resources-plugin>2.7</version-maven-resources-plugin>
         <version-maven-source-plugin>2.3</version-maven-source-plugin>
-        <version-maven-surefire-plugin>2.18.1</version-maven-surefire-plugin>
+        <version-maven-surefire-plugin>2.19.1</version-maven-surefire-plugin>
         <version-maven-war-plugin>3.0.0</version-maven-war-plugin>
         <version-properties-maven-plugin>1.0.0</version-properties-maven-plugin>
         <version-shrinkwrap-resolver-maven-plugin>2.2.6</version-shrinkwrap-resolver-maven-plugin>
@@ -376,7 +376,7 @@
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>3.2.3</version>
-                                </requireMavenVersion>                
+                                </requireMavenVersion>
                             </rules>
                         </configuration>
                     </execution>
@@ -419,7 +419,7 @@
         <system>GitHub</system>
         <url>https://github.com/${github.namespace}/${github.project}/issues</url>
     </issueManagement>
-    
+
     <!-- Repositories -->
     <repositories>
         <repository>


### PR DESCRIPTION
@tdiesler in the end, the integration tests may be run by a CI. The CI only has to keep a filled in copy of `oauth2-options.properties` [1]. I have one such config ready here and I can share it with you. 

The Gmail API tests are off by default. They have to be activated by `-Pgoogle-api-test`.

[1] https://github.com/wildfly-extras/wildfly-camel/commit/8ef62250e93d62b0582953943a7bd2ae166ce539#diff-026ccaa063bc8adbbefd162536836d0fR22