### PR TITLE
[resolves #2290] DockerIntegrationTest fails when boot2docker is not …

### DIFF
--- a/itests/standalone/docker/src/test/java/org/wildfly/camel/test/docker/DockerIntegrationTest.java
+++ b/itests/standalone/docker/src/test/java/org/wildfly/camel/test/docker/DockerIntegrationTest.java
@@ -26,8 +26,8 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.arquillian.cube.docker.impl.requirement.RequiresDocker;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
@@ -38,7 +38,7 @@ import org.wildfly.camel.test.common.utils.TestUtils;
 import org.wildfly.extension.camel.CamelAware;
 
 @CamelAware
-@RunWith(Arquillian.class)
+@RunWith(ArquillianConditionalRunner.class)
 @RequiresDocker
 public class DockerIntegrationTest {
 


### PR DESCRIPTION
…present