### PR TITLE
[resolves #2390] <system-properties> indented not correctly in the patched standalone-*.xml

### DIFF
--- a/config/src/main/java/org/wildfly/extension/camel/config/WildFlyCamelConfigPlugin.java
+++ b/config/src/main/java/org/wildfly/extension/camel/config/WildFlyCamelConfigPlugin.java
@@ -92,7 +92,7 @@ public final class WildFlyCamelConfigPlugin implements ConfigPlugin {
             int pos = rootElement.indexOf(extensions);
             rootElement.addContent(pos + 1, new Text("    "));
             rootElement.addContent(pos + 1, element);
-            rootElement.addContent(pos + 1, new Text("\n"));
+            rootElement.addContent(pos + 1, new Text("\n    "));
         }
 
         Map<String, Element> propertiesByName = ConfigSupport.mapByAttributeName(element.getChildren(), "name");


### PR DESCRIPTION
Currently it outputs like this:
```
    </extensions>
<system-properties>
       <property name="hawtio.authenticationEnabled" value="true" />
       <property name="hawtio.offline" value="true" />
       <property name="hawtio.realm" value="hawtio-domain" />
    </system-properties>
```

