### PR TITLE
[resolves #2391] Replace WildFly and WildFly-Camel with variables in …

### DIFF
--- a/docs/guide/cloud/openshift-local.adoc
+++ b/docs/guide/cloud/openshift-local.adoc
@@ -45,9 +45,9 @@ You should now be able to use docker on the command line of your host, talking t
 $ docker ps
 ----
 
-#### Running WildFly-Camel
+#### Running {wildfly-camel}
 
-With every WildFly-Camel release we also publish the latest https://registry.hub.docker.com/u/wildflyext/wildfly-camel/[wildflyext/wildfly-camel,window=_blank] image.
+With every {wildfly-camel} release we also publish the latest https://registry.hub.docker.com/u/wildflyext/wildfly-camel/[wildflyext/wildfly-camel,window=_blank] image.
 
 You can run the standalone container like this
 
@@ -60,7 +60,7 @@ image::console-standalone.png[]
 
 #### Create an OpenShift project
 
-Here we run a set of WildFly Camel servers on https://www.openshift.org[OpenShift Origin,window=_blank]. 
+Here we run a set of {wildfly-camel} servers on https://www.openshift.org[OpenShift Origin,window=_blank]. 
 The target platform is the local OpenShift instance that we created above. 
 
 image::example-rest-design.png[]

--- a/docs/guide/cloud/openshift-s2i.adoc
+++ b/docs/guide/cloud/openshift-s2i.adoc
@@ -1,6 +1,6 @@
 ### Source to Image
 
-The WildFly-Camel https://hub.docker.com/r/wildflyext/wildfly-camel/[Docker image,window=_blank] is capabale of performing https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[Source-To-Image,window=_blank] builds.
+The {wildfly-camel} https://hub.docker.com/r/wildflyext/wildfly-camel/[Docker image,window=_blank] is capabale of performing https://docs.openshift.org/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[Source-To-Image,window=_blank] builds.
 
 This enables you to build reproducable images from source.
 
@@ -8,7 +8,7 @@ This enables you to build reproducable images from source.
 
 First you'll need to download and install the S2I tooling from https://github.com/openshift/source-to-image[here,window=_blank].
 
-Then you can build and run a Docker image from source. For example, to build the WildFly-Camel CDI quickstart:
+Then you can build and run a Docker image from source. For example, to build the {wildfly-camel} CDI quickstart:
 
 [source,options="nowrap",subs="attributes"]
 $ s2i build https://github.com/wildfly-extras/wildfly-camel-examples.git -r {version} --context-dir camel-cdi wildflyext/wildfly-camel:{version} wildfly-camel-example-cdi
@@ -22,9 +22,9 @@ http://{ec2-pub-ip}:8080/example-camel-cdi?name=Kermit[,window=_blank]
 
 #### S2I with OpenShift Origin
 
-WildFly-Camel provides an OpenShift builder image, which enables you to do a source to image in OpenShift.
+{wildfly-camel} provides an OpenShift builder image, which enables you to do a source to image in OpenShift.
 
-First add the WildFly-Camel S2I ImageStream.
+First add the {wildfly-camel} S2I ImageStream.
 
 [source,options="nowrap"]
 $ oc apply -f http://wildfly-extras.github.io/wildfly-camel/sources/wildfly-camel-imagestream.json
@@ -34,7 +34,7 @@ When you select 'Add to Project' in the OpenShift web console you should see a n
 
 image::wildfly-camel-s2i-builder01.png[]
 
-To build the latest release of the WildFly-Camel CDI example you would enter:
+To build the latest release of the {wildfly-camel} CDI example you would enter:
 
 [cols="1,2",width="80%"]
 |=======

--- a/docs/guide/components/camel-activemq.adoc
+++ b/docs/guide/components/camel-activemq.adoc
@@ -4,17 +4,17 @@ Camel ActiveMQ integration is provided by the http://camel.apache.org/activemq.h
 
 The component can be configured to work with an embedded or external broker. For Wildfly / EAP container managed connection pools and XA-Transaction support, the http://activemq.apache.org/resource-adapter.html[ActiveMQ Resource Adapter,window=_blank] can be configured into the container configuration file.
 
-#### WildFly ActiveMQ resource adapter configuration
+#### {wildfly} ActiveMQ resource adapter configuration
 
 Download the https://repository.apache.org/content/repositories/releases/org/apache/activemq/activemq-rar/5.11.1/activemq-rar-5.11.1.rar[ActiveMQ resource adapter rar file,window=_blank]. The following steps outline how to configure the ActiveMQ resource adapter.
 
-__1)__ Make sure your WildFly instance is stopped.
+__1)__ Make sure your {wildfly} instance is stopped.
 
-__2)__ Copy the downloaded resource adapter to the relevant WildFly deployment directory. For standalone mode:
+__2)__ Copy the downloaded resource adapter to the relevant {wildfly} deployment directory. For standalone mode:
 
  cp activemq-rar-5.11.1.rar ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar
 
-__3)__ Configure the WildFly resource adapters subsystem for the ActiveMQ adapter.
+__3)__ Configure the {wildfly} resource adapters subsystem for the ActiveMQ adapter.
 
 [source,xml,options="nowrap"]
 <subsystem xmlns="urn:jboss:domain:resource-adapters:2.0">  
@@ -69,7 +69,7 @@ The values of the UserName and Password configuration properties must be chosen 
 You might need to change the value of the ServerUrl configuration property to match the actual hostname and port exposed by the external broker.
 
 
-__4)__ Start WildFly. If everything is configured correctly, you should see a message within the WildFly server.log like.
+__4)__ Start {wildfly}. If everything is configured correctly, you should see a message within the {wildfly} server.log like.
 
 [source,options="nowrap"]
 13:16:08,412 INFO  [org.jboss.as.connector.deployment] (MSC service thread 1-5) JBAS010406: Registered connection factory java:/AMQConnectionFactory`
@@ -99,7 +99,7 @@ public class ActiveMQRouteBuilder extends RouteBuilder {
 }
 ----
 
-A log message will be output to the console each time a message is added to the WildFlyCamelQueue destination. To verify that the messages really are being placed onto the queue, we can use the ../features/hawtio.md[Hawtio console,window=_blank] provided by the WildFly Camel subsystem.
+A log message will be output to the console each time a message is added to the WildFlyCamelQueue destination. To verify that the messages really are being placed onto the queue, we can use the ../features/hawtio.md[Hawtio console,window=_blank] provided by the {wildfly-camel} subsystem.
 
 image::activemq-queue-browse.png[]
 
@@ -122,7 +122,7 @@ public void configure() throws Exception {
 
 The ActiveMQ resource adapter is required as we will want to leverage XA transaction support, connection pooling etc.
 
-The XML snippet below shows how the resource adapter is configured within the WildFly server XML configuration. Notice that the `ServerURL` is set to use an embedded broker. The connection factory is bound to the JNDI name `java:/ActiveMQConnectionFactory`. This will be looked up in the RouteBuilder example that follows.
+The XML snippet below shows how the resource adapter is configured within the {wildfly} server XML configuration. Notice that the `ServerURL` is set to use an embedded broker. The connection factory is bound to the JNDI name `java:/ActiveMQConnectionFactory`. This will be looked up in the RouteBuilder example that follows.
 
 Finally, two queues are configured named 'queue1' and 'queue2'.
 
@@ -144,7 +144,7 @@ Finally, two queues are configured named 'queue1' and 'queue2'.
 </subsystem>  
 
 ##### Transaction Manager
-The camel-activemq component requires a transaction manager of type `org.springframework.transaction.PlatformTransactionManager`. Therefore, we begin by creating a bean extending `JtaTransactionManager` which fulfills this requirement. Note that the bean is annotated with `@Named` to allow the bean to be registered within the Camel bean registry. Also note that the WildFly transaction manager and user transaction instances are injected using CDI.
+The camel-activemq component requires a transaction manager of type `org.springframework.transaction.PlatformTransactionManager`. Therefore, we begin by creating a bean extending `JtaTransactionManager` which fulfills this requirement. Note that the bean is annotated with `@Named` to allow the bean to be registered within the Camel bean registry. Also note that the {wildfly} transaction manager and user transaction instances are injected using CDI.
 
 [source,java,options="nowrap"]
 ----
@@ -232,4 +232,3 @@ Refer to the link:index.html#_jms_security[JMS security section].
 #### Code examples on GitHub
 
 An example https://github.com/wildfly-extras/wildfly-camel-examples/tree/master/camel-activemq[camel-activemq application,window=_blank] is available on GitHub.
-

--- a/docs/guide/components/camel-file2.adoc
+++ b/docs/guide/components/camel-file2.adoc
@@ -2,7 +2,7 @@
 
 The http://camel.apache.org/file2.html[file,window=_blank] component provides access to file systems, allowing files to be processed by any other Camel Components or messages from other components to be saved to disk.
 
-Here is a simple route that prepends the message with 'Hello' and writes the result to a file in WildFly's data directory.
+Here is a simple route that prepends the message with 'Hello' and writes the result to a file in {wildfly}'s data directory.
 
 [source,java,options="nowrap"]
 ----

--- a/docs/guide/components/camel-mail.adoc
+++ b/docs/guide/components/camel-mail.adoc
@@ -2,11 +2,11 @@
 
 Interaction with email is provided by the http://camel.apache.org/mail.html[mail,window=_blank] component.
 
-By default, Camel will create its own mail session and use this to interact with your mail server. Since WildFly already provides a mail subsystem with all of the relevant support for secure connections, username / password encryption etc, it is recommended to configure your mail sessions within the WildFly configuration and use JNDI to wire them into your Camel endpoints.
+By default, Camel will create its own mail session and use this to interact with your mail server. Since {wildfly} already provides a mail subsystem with all of the relevant support for secure connections, username / password encryption etc, it is recommended to configure your mail sessions within the {wildfly} configuration and use JNDI to wire them into your Camel endpoints.
 
-#### WildFly configuration
+#### {wildfly} configuration
 
-First we configure the WildFly mail subsystem for our Mail server. This example adds configuration for Google Mail IMAP and SMTP .
+First we configure the {wildfly} mail subsystem for our Mail server. This example adds configuration for Google Mail IMAP and SMTP .
 
 An additional mail-session is configured after the 'default' session.
 
@@ -54,7 +54,7 @@ If you need to configure POP3 sessions, the principals are the same as defined i
 #### Camel route configuration
 
 ##### Mail producer
-This example uses the SMTPS protocol, together with CDI in conjunction with the camel-cdi component. The Java mail session that we configured within the WildFly configuration is injected into a Camel RouteBuilder through JNDI.
+This example uses the SMTPS protocol, together with CDI in conjunction with the camel-cdi component. The Java mail session that we configured within the {wildfly} configuration is injected into a Camel RouteBuilder through JNDI.
 
 ###### Route builder SMTPS example
 The GMail mail session is injected into a Producer class using the `@Resource` annotation with a reference to the `jndi-name` attribute that we  previously configured. This allows us to reference the mail session on the camel-mail endpoint configuration.
@@ -111,7 +111,7 @@ public void configure() throws Exception {
 
 ##### SSL configuration
 
-WildFly can be configured to manage Java mail sessions and their associated transports using SSL / TLS. When configuring mail sessions you can configure SSL or TLS on server types:
+{wildfly} can be configured to manage Java mail sessions and their associated transports using SSL / TLS. When configuring mail sessions you can configure SSL or TLS on server types:
 
 * smtp-server
 * imap-server
@@ -132,5 +132,3 @@ component guide. Camel also has a http://camel.apache.org/security.html[security
 #### Code examples on GitHub
 
 An example https://github.com/wildfly-extras/wildfly-camel-examples/tree/master/camel-mail[camel-mail application,window=_blank] is available on GitHub for you to try out sending / receiving email.
-
-

--- a/docs/guide/components/camel-netty4.adoc
+++ b/docs/guide/components/camel-netty4.adoc
@@ -2,7 +2,7 @@
 
 Netty client / server support in Camel is provided by the http://camel.apache.org/netty4.html[netty4,window=_blank] component.
 
-WildFly 8 and EAP 6.4 are bundled with module libraries supporting the http://netty.io/[Netty,window=_blank] 
+{wildfly} 8 and EAP 6.4 are bundled with module libraries supporting the http://netty.io/[Netty,window=_blank] 
 project version 4. Therefore, the standard http://camel.apache.org/netty.html[netty component,window=_blank] will not work since it is compatible with Netty version 3 only.
 
 #### Simple Netty Client / Server Test
@@ -41,4 +41,3 @@ Assert.assertEquals("Hello Kermit", result);
 
 camelContext.stop();
 ----
-

--- a/docs/guide/components/camel-rest.adoc
+++ b/docs/guide/components/camel-rest.adoc
@@ -5,7 +5,7 @@ component allows you to define REST endpoints using the http://camel.apache.org/
 
 [CAUTION]
 ====
-The WildFly Camel Subsystem only supports the camel-servlet and camel-undertow components for use with the REST DSL. Attempts to configure other components will not work.
+The {wildfly-camel} Subsystem only supports the camel-servlet and camel-undertow components for use with the REST DSL. Attempts to configure other components will not work.
 ====
 
 [source,java,options="nowrap"]
@@ -18,4 +18,3 @@ camelctx.addRoutes(new RouteBuilder() {
         from("direct:hello").transform(simple("Hello ${header.name}"));
     }
 });
-

--- a/docs/guide/components/camel-sap.adoc
+++ b/docs/guide/components/camel-sap.adoc
@@ -6,12 +6,12 @@ There are remote function call (RFC) components that support the sRFC, tRFC, and
 
 [NOTE]
 ====
-A prerequisite for using the Camel SAP component is that the SAP Java Connector (SAP JCo) libraries and the SAP IDoc library are available for the WildFly Camel Subsytem to use. **The subsystem distribution does not include these libraries**. You will need access to the http://service.sap.com/connectors[SAP Service Marketplace,window=_blank] in order to obtain them.
+A prerequisite for using the Camel SAP component is that the SAP Java Connector (SAP JCo) libraries and the SAP IDoc library are available for the {wildfly-camel} Subsytem to use. **The subsystem distribution does not include these libraries**. You will need access to the http://service.sap.com/connectors[SAP Service Marketplace,window=_blank] in order to obtain them.
 ====
 
 #### Configuring the camel-sap module
 
-Before using camel-sap, an additional WildFly / EAP modules needs to be configured so that the subsystem can discover the new functionality.
+Before using camel-sap, an additional {wildfly} modules needs to be configured so that the subsystem can discover the new functionality.
 
 Your application server should be stopped before making the following changes.
 
@@ -126,5 +126,3 @@ You should see an XML structure like the following containing customer records.
 
 The example above only scratches the surface of the functionality provided by the camel-sap component. For comprehensive component documentation visit
 the https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Fuse/6.2/html/Apache_Camel_Component_Reference/SAP.html[Camel SAP Component Reference,window=_blank].
-
-

--- a/docs/guide/components/camel-sql.adoc
+++ b/docs/guide/components/camel-sql.adoc
@@ -86,7 +86,7 @@ Support for the following Spring JDBC XML configurations is supported
 
 [NOTE]
 ====
-Only H2 databases are supported by default as WildFly has native support for this. If you want to use other embedded database providers, you will need
+Only H2 databases are supported by default as {wildfly} has native support for this. If you want to use other embedded database providers, you will need
 to install the appropriate database driver.
 ====
 
@@ -96,4 +96,3 @@ to install the appropriate database driver.
 <jdbc:initialize-database data-source="datasource">
   <jdbc:script location="classpath:db-init.sql"/>
 </jdbc:initialize-database>
-

--- a/docs/guide/components/camel-undertow.adoc
+++ b/docs/guide/components/camel-undertow.adoc
@@ -3,5 +3,4 @@
 The http://camel.apache.org/undertow.html[undertow,window=_blank] 
 component provides HTTP-based endpoints for consuming and producing HTTP requests. That is, the http://undertow.io/[Undertow,window=_blank] component behaves as a simple Web server. Undertow can also be used as a http client which mean you can also use it with Camel as a producer.
 
-The Undertow component integrates with the Undertow server provided by WildFly.
-
+The Undertow component integrates with the Undertow server provided by {wildfly}.

--- a/docs/guide/components/index.adoc
+++ b/docs/guide/components/index.adoc
@@ -404,7 +404,7 @@ Here is an example for the camel-ftp component
   </dependencies>
 </module>
 
-Please make sure you don't duplicate modules that are already available in WildFly and can be reused.
+Please make sure you don't duplicate modules that are already available in {wildfly} and can be reused.
 
 [discrete]
 #### Add a reference to the component

--- a/docs/guide/features/arquillian.adoc
+++ b/docs/guide/features/arquillian.adoc
@@ -1,9 +1,9 @@
 [discrete]
 ### Arquillian Test Support
 
-The WildFly Camel test suite uses the WildFly http://arquillian.org/[Arquillian,window=_blank] managed container. This can connect to an already running WildFly instance or alternatively start up a standalone server instance when needed.
+The {wildfly-camel} test suite uses the WildFly http://arquillian.org/[Arquillian,window=_blank] managed container. This can connect to an already running {wildfly} instance or alternatively start up a standalone server instance when needed.
 
-A number of test enrichers have been implemented that allow you to have these WildFly Camel specific types injected into your Arquillian test cases.
+A number of test enrichers have been implemented that allow you to have these {wildfly-camel} specific types injected into your Arquillian test cases.
 
 [source,java,options="nowrap"]
 ----

--- a/docs/guide/features/context-deployments.adoc
+++ b/docs/guide/features/context-deployments.adoc
@@ -1,7 +1,7 @@
 [discrete]
 ### Camel Context Deployments
 
-Camel contexts can be deployed to WildFly with a **-camel-context.xml** suffix.
+Camel contexts can be deployed to {wildfly} with a **-camel-context.xml** suffix.
 
 1. As a standalone XML file
 2. As part of another supported deployment
@@ -13,4 +13,3 @@ A deployed Camel context is CDI injectable like this
 [source,java,options="nowrap"]
 @Resource(name = "java:jboss/camel/context/mycontext")
 CamelContext camelContext;
-

--- a/docs/guide/features/index.adoc
+++ b/docs/guide/features/index.adoc
@@ -1,6 +1,6 @@
 ## Features
 
-This chapter provides more detailed information about WildFly-Camel features.
+This chapter provides more detailed information about {wildfly-camel} features.
 
 include::context-definitions.adoc[]
 include::context-deployments.adoc[]

--- a/docs/guide/index.adoc
+++ b/docs/guide/index.adoc
@@ -11,12 +11,15 @@ Thomas Diesler;James Netherton
 :ec2-pub-ip-dash: 1-2-3-4
 :ec2-pub-ip: 1.2.3.4
 
+:wildfly: WildFly
+:wildfly-camel: WildFly-Camel
+
 (C) 2016 The original authors.
 
 
 Provides http://camel.apache.org[Apache Camel,window=_blank] integration with the http://wildfly.org[WildFly Application Server,window=_blank].
 
-The WildFly-Camel subsystem allows you to add Camel Routes as part of the WildFly configuration. Routes can be deployed as part of JavaEE applications. JavaEE components can access the Camel Core API and various Camel Component APIs.
+The {wildfly-camel} subsystem allows you to add Camel Routes as part of the WildFly configuration. Routes can be deployed as part of JavaEE applications. JavaEE components can access the Camel Core API and various Camel Component APIs.
 
 Your Enterprise Integration Solution can be architected as a combination of JavaEE and Camel functionality.
 

--- a/docs/guide/javaee/jaxrs.adoc
+++ b/docs/guide/javaee/jaxrs.adoc
@@ -105,7 +105,7 @@ Note that the REST DSL configuration starts with `restConfiguration().component(
 
 [CAUTION]
 ====
-The WildFly Camel Subsystem only supports the camel-servlet and camel-undertow components for use with the REST DSL. Attempts to configure other components will not work.
+The {wildfly-camel} Subsystem only supports the camel-servlet and camel-undertow components for use with the REST DSL. Attempts to configure other components will not work.
 ====
 
 By setting the binding mode, Camel can marshal and unmarshal JSON data either by specifying a 'produces()' or 'type()' configuration step.
@@ -117,4 +117,3 @@ Refer to the link:index.html#_jax_rs_security[JAX-RS security section].
 #### Code examples on GitHub
 
 An example https://github.com/wildfly-extras/wildfly-camel-examples/tree/master/camel-cxf-jaxrs[Camel CXF application,window=_blank] is available on GitHub.
-

--- a/docs/guide/javaee/jaxws.adoc
+++ b/docs/guide/javaee/jaxws.adoc
@@ -1,7 +1,7 @@
 ### JAX-WS
 
 WebService support is provided through the http://camel.apache.org/cxf.html[cxf,window=_blank] 
-component which integrates with the WildFly WebServices subsystem that also uses http://cxf.apache.org/[Apache CXF,window=_blank].
+component which integrates with the {wildfly} WebServices subsystem that also uses http://cxf.apache.org/[Apache CXF,window=_blank].
 
 
 #### JAX-WS CXF Producer
@@ -11,7 +11,7 @@ The following code example uses CXF to consume a web service which has been depl
 The following simple web service has a simple 'greet' method which will concatenate two string arguments together
 and return them.
 
-When the WildFly web service subsystem detects classes containing JAX-WS annotations, it bootstraps a CXF endpoint. In this example
+When the {wildfly} web service subsystem detects classes containing JAX-WS annotations, it bootstraps a CXF endpoint. In this example
 the service endpoint will be located at http://hostname:port/context-root/greeting.
 
 [source,java,options="nowrap"]
@@ -98,4 +98,3 @@ Refer to the link:index.html#_jax_ws_security[JAX-WS security section].
 Example JAX-WS applications are available on GitHub.
 
 * https://github.com/wildfly-extras/wildfly-camel-examples/tree/master/camel-cxf-jaxws[Camel CXF application,window=_blank]
-

--- a/docs/guide/javaee/jms.adoc
+++ b/docs/guide/javaee/jms.adoc
@@ -1,14 +1,14 @@
 ### JMS
 
 Messaging support is provided through the http://camel.apache.org/jms.html[jms,window=_blank] 
-component which integrates with the WildFly Messaging (https://activemq.apache.org/artemis/)[ActiveMQ Artemis,window=_blank]) subsystem.
+component which integrates with the {wildfly} Messaging (https://activemq.apache.org/artemis/)[ActiveMQ Artemis,window=_blank]) subsystem.
 
 Integration with other JMS implementations is possible through configuration of vendor specific resource adapters, or if not available, by using the JBoss Generic JMS resource adapter.
 
 
-#### WildFly JMS configuration
+#### {wildfly} JMS configuration
 
-The WildFly https://docs.jboss.org/author/display/WFLY8/Messaging+configuration[messaging subsystem,window=_blank] can be configured from within the standard WildFly XML configuration files e.g. standalone.xml.
+The {wildfly} https://docs.jboss.org/author/display/WFLY8/Messaging+configuration[messaging subsystem,window=_blank] can be configured from within the standard {wildfly} XML configuration files e.g. standalone.xml.
 
 For the examples that follow we use the embedded ActiveMQ Artemis in memory instance. We first configure a new JMS queue on the messaging subsystem by adding the following XML configuration to the jms-destinations section.
 
@@ -22,16 +22,16 @@ Alternatively you could use a CLI script to add the queue.
 [source,options="nowrap"]
 $ jms-queue add --queue-address=WildFlyCamelQueue --entries=queue/WildFlyCamelQueue,java:/jms/queue/WildFlyCamelQueue
 
-Or, you could create a `messaging-deployment` configuration within a custom jms.xml deployment descriptor. See section 'Deployment of -jms.xml files' within the WildFly messaging subsystem documentation for more information.
+Or, you could create a `messaging-deployment` configuration within a custom jms.xml deployment descriptor. See section 'Deployment of -jms.xml files' within the {wildfly} messaging subsystem documentation for more information.
 
 #### Camel route configuration
-The following JMS producer and consumer examples make use of WildFly's embedded ActiveMQ Artemis sever to publish and consume messages to and from destinations.
+The following JMS producer and consumer examples make use of {wildfly}'s embedded ActiveMQ Artemis sever to publish and consume messages to and from destinations.
 
 The examples also use CDI in conjunction with the camel-cdi component. JMS ConnectionFactory instances are injected into the Camel RouteBuilder through JNDI lookups.
 
 ##### JMS Producer
 
-The RouteBuilder begins by injecting the `DefaultJMSConnectionFactory` connection factory from JNDI. If you're wondering where the connection factory is defined, look at the WildFly XML configuration and you'll see it is defined within the messaging subsystem.
+The RouteBuilder begins by injecting the `DefaultJMSConnectionFactory` connection factory from JNDI. If you're wondering where the connection factory is defined, look at the {wildfly} XML configuration and you'll see it is defined within the messaging subsystem.
 
 Next a timer endpoint runs every 10 seconds to send an XML payload to the WildFlyCamelQueue destination that we configured earlier.
 
@@ -60,7 +60,7 @@ public class JmsRouteBuilder extends RouteBuilder {
 }
 ----
 
-A log message will be output to the console each time a JMS message is added to the WildFlyCamelQueue destination. To verify that the messages really are being placed onto the queue, we can use the WildFly administration console.
+A log message will be output to the console each time a JMS message is added to the WildFlyCamelQueue destination. To verify that the messages really are being placed onto the queue, we can use the {wildfly} administration console.
 
 image::jms-queue-browse.png[]
 
@@ -88,9 +88,9 @@ public void configure() throws Exception {
 ----
 
 ##### JMS Transactions
-To enable Camel JMS routes to participate in JMS transactions, some additional configuration is required. Since camel-jms is built around spring-jms, we need to configure some Spring classes to enable them to work with WildFly's transaction manager and connection factory. The following code example demonstrates how to use CDI to configure a transactional JMS Camel route.
+To enable Camel JMS routes to participate in JMS transactions, some additional configuration is required. Since camel-jms is built around spring-jms, we need to configure some Spring classes to enable them to work with {wildfly}'s transaction manager and connection factory. The following code example demonstrates how to use CDI to configure a transactional JMS Camel route.
 
-The camel-jms component requires a transaction manager of type `org.springframework.transaction.PlatformTransactionManager`. Therefore, we begin by creating a bean extending `JtaTransactionManager`. Note that the bean is annotated with `@Named` to allow the bean to be registered within the Camel bean registry. Also note that the WildFly transaction manager and user transaction instances are injected using CDI.
+The camel-jms component requires a transaction manager of type `org.springframework.transaction.PlatformTransactionManager`. Therefore, we begin by creating a bean extending `JtaTransactionManager`. Note that the bean is annotated with `@Named` to allow the bean to be registered within the Camel bean registry. Also note that the {wildfly} transaction manager and user transaction instances are injected using CDI.
 
 [source,java,options="nowrap"]
 ----
@@ -123,7 +123,7 @@ public class CdiRequiredPolicy extends SpringTransactionPolicy {
   }
 }
 
-Now we can configure our Camel RouteBuilder class and inject the dependencies needed for the Camel JMS component. The WildFly XA connection factory is injected together with the transaction manager we configured earlier.
+Now we can configure our Camel RouteBuilder class and inject the dependencies needed for the Camel JMS component. The {wildfly} XA connection factory is injected together with the transaction manager we configured earlier.
 
 In this example RouteBuilder, whenever any messages are consumed from queue1, they are routed to another JMS queue named queue2. Messages consumed from queue2 result in JMS transaction being rolled back using the rollback() DSL method. This results in the original message being placed onto the dead letter queue(DLQ).
 
@@ -150,7 +150,7 @@ public class JMSRouteBuilder extends RouteBuilder {
       .transacted("PROPAGATION_REQUIRED")
       .to("jms:queue:queue2");
 
-    // Force the transaction to roll back. The message will end up on the WildFly 'DLQ' message queue
+    // Force the transaction to roll back. The message will end up on the Wildfly 'DLQ' message queue
     from("jms:queue:queue2")
       .to("log:end")
       .rollback();
@@ -159,13 +159,13 @@ public class JMSRouteBuilder extends RouteBuilder {
 
 ##### Remote JMS destinations
 
-It's possible for one WildFly instance to send messages to ActiveMQ Artemis destinations configured on another WildFly instance through https://docs.jboss.org/author/display/WFLY8/Remote+JNDI+Reference[remote JNDI,window=_blank].
+It's possible for one {wildfly} instance to send messages to ActiveMQ Artemis destinations configured on another {wildfly} instance through https://docs.jboss.org/author/display/WFLY8/Remote+JNDI+Reference[remote JNDI,window=_blank].
 
-Some additional WildFly configuration is required to achieve this. First an exported JMS queue is configured.
+Some additional {wildfly} configuration is required to achieve this. First an exported JMS queue is configured.
 
 Only JNDI names bound in the `java:jboss/exported` namespace are considered as candidates for remote clients, so the queue is named appropriately.
 
-Note that the queue must be configured on the WildFly client application server __and__ the WildFly remote server.
+Note that the queue must be configured on the {wildfly} client application server __and__ the {wildfly} remote server.
 
 [source,xml,options="nowrap"]
 <jms-queue name="RemoteQueue">
@@ -176,7 +176,7 @@ Before the client can connect to the remote server, user access credentials need
 
 The RouteBuilder implementation is different to the previous examples. Instead of injecting the connection factory, we need to configure an InitalContext and retrieve it from JNDI ourselves.
 
-The `configureInitialContext` method creates this InitialContext. Notice that we need to set a provider URL which should reference your remote WildFly instance host name and port number. This example uses the WildFly JMS http-connector, but there are alternatives documented https://docs.jboss.org/author/display/WFLY8/Messaging+configuration[here,window=_blank].
+The `configureInitialContext` method creates this InitialContext. Notice that we need to set a provider URL which should reference your remote {wildfly} instance host name and port number. This example uses the {wildfly} JMS http-connector, but there are alternatives documented https://docs.jboss.org/author/display/WFLY8/Messaging+configuration[here,window=_blank].
 
 Finally the route is configured to send an XML payload every 10 seconds to the remote destination configured earlier - 'RemoteQueue'.
 
@@ -216,4 +216,3 @@ Refer to the link:index.html#_jms_security[JMS security section].
 #### Code examples on GitHub
 
 An example https://github.com/wildfly-extras/wildfly-camel-examples/tree/master/camel-jms[camel-jms application,window=_blank] is available on GitHub.
-

--- a/docs/guide/javaee/jmx.adoc
+++ b/docs/guide/javaee/jmx.adoc
@@ -1,6 +1,6 @@
 ### JMX
 
-Management support is provided through the http://camel.apache.org/jmx.html[jmx,window=_blank] component which integrates with the WildFly JMX subsystem.
+Management support is provided through the http://camel.apache.org/jmx.html[jmx,window=_blank] component which integrates with the {wildfly} JMX subsystem.
 
 [source,java,options="nowrap"]
 ----
@@ -20,4 +20,3 @@ ConsumerTemplate consumer = camelctx.createConsumerTemplate();
 MonitorNotification notifcation = consumer.receiveBody("direct:end", MonitorNotification.class);
 Assert.assertEquals("ExchangesTotal", notifcation.getObservedAttribute());
 ----
-

--- a/docs/guide/javaee/jndi.adoc
+++ b/docs/guide/javaee/jndi.adoc
@@ -1,6 +1,6 @@
 ### JNDI
 
-JNDI integration is provided by a WildFly specific CamelContext, which is can be obtained like this
+JNDI integration is provided by a {wildfly} specific CamelContext, which is can be obtained like this
 
 [source,java,options="nowrap"]
 InitialContext inictx = new InitialContext();
@@ -23,4 +23,3 @@ camelctx.addRoutes(new RouteBuilder() {
     }
 });
 camelctx.start();
-

--- a/docs/guide/security/index.adoc
+++ b/docs/guide/security/index.adoc
@@ -1,6 +1,6 @@
 ## Security
 
-Security in WildFly is a broad topic. Both WildFly and Camel have well documented, stadardised methods of securing configuration, endpoints and payloads.
+Security in {wildfly} is a broad topic. Both {wildfly} and Camel have well documented, stadardised methods of securing configuration, endpoints and payloads.
 
 include::jaxrs.adoc[]
 
@@ -8,6 +8,6 @@ include::jaxws.adoc[]
 
 include::jms.adoc[]
 
-In addition to that, we use Camel's notion of Route Policies to integrate with the WildFly security system.
+In addition to that, we use Camel's notion of Route Policies to integrate with the {wildfly} security system.
 
 include::policy.adoc[]

--- a/docs/guide/security/policy.adoc
+++ b/docs/guide/security/policy.adoc
@@ -1,6 +1,6 @@
 ### Route Policy
 
-Camel supports the notion of http://camel.apache.org/routepolicy.html[RoutePolicies,window=_blank], which can be used to integrate with the WildFly security system. There are currently two supported scenarios for security integration.
+Camel supports the notion of http://camel.apache.org/routepolicy.html[RoutePolicies,window=_blank], which can be used to integrate with the {wildfly} security system. There are currently two supported scenarios for security integration.
 
 #### Camel calls into JavaEE
 
@@ -57,5 +57,3 @@ Subject subject = new Subject();
 subject.getPrincipals().add(new DomainPrincipal(domain));
 subject.getPrincipals().add(new EncodedUsernamePasswordPrincipal(username, password));
 producer.requestBodyAndHeader("direct:start", "Kermit", Exchange.AUTHENTICATION, subject, String.class);
-
-

--- a/docs/guide/start/compatibility.adoc
+++ b/docs/guide/start/compatibility.adoc
@@ -1,6 +1,6 @@
 ## Compatibility
 
-The WildFly compatibility matrix
+The {wildfly} compatibility matrix
 
 [cols="2*",width="60%"]
 |===

--- a/docs/guide/start/index.adoc
+++ b/docs/guide/start/index.adoc
@@ -1,11 +1,11 @@
 ## Getting Started
 
-This chapter takes you through the first steps of getting WildFly-Camel and provides the initial pointers to get up and running.
+This chapter takes you through the first steps of getting {wildfly-camel} and provides the initial pointers to get up and running.
 
 [discrete]
 ### Download the Distribution
 
-WildFly Camel is distributed as
+WildFly-Camel is distributed as
 
 1. WildFly Patch - https://github.com/wildflyext/wildfly-camel/releases[wildfly-camel-patch]
 2. Docker Image - https://registry.hub.docker.com/u/wildflyext/wildfly-camel/[wildflyext/wildfly-camel]
@@ -53,7 +53,7 @@ There are currently three triggers that can be used to enable Camel for a deploy
 [discrete]
 ### Docker Image
 
-The easiest and most portable way to run WildFly-Camel is to use the https://registry.hub.docker.com/u/wildflyext/wildfly-camel[wildflyext/wildfly-camel] distribution.
+The easiest and most portable way to run {wildfly-camel} is to use the https://registry.hub.docker.com/u/wildflyext/wildfly-camel[wildflyext/wildfly-camel] distribution.
 
 [options="nowrap"]
  $ docker run --rm -ti -p 8080:8080 -p 9990:9990 -e WILDFLY_MANAGEMENT_USER=admin -e WILDFLY_MANAGEMENT_PASSWORD=admin wildflyext/wildfly-camel
@@ -82,5 +82,3 @@ mvn archetype:generate -DarchetypeGroupId=org.wildfly.camel.archetypes \
                        -DartifactId=my-camel-spring-application
 
 Instructions on how to build, test and run the project can be found within the generated README files. 
-
-

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -35,6 +35,8 @@
     <properties>
         <ec2-pub-ip-dash>1-2-3-4</ec2-pub-ip-dash>
         <ec2-pub-ip>1.2.3.4</ec2-pub-ip>
+        <wildfly>WildFly</wildfly>
+        <wildfly-camel>WildFly-Camel</wildfly-camel>
     </properties>
     
     <build>
@@ -58,6 +60,8 @@
                                 <camel-version>${version.apache.camel}</camel-version>
                                 <ec2-pub-ip>${ec2-pub-ip}</ec2-pub-ip>
                                 <ec2-pub-ip-dash>${ec2-pub-ip-dash}</ec2-pub-ip-dash>
+                                <wildfly>${wildfly}</wildfly>
+                                <wildfly-camel>${wildfly-camel}</wildfly-camel>
                                 <version>${project.version}</version>
                             </attributes>
                         </configuration>


### PR DESCRIPTION
…user guide docs. I took some care to avoid replacing text in code examples in the doc, so that they don't get messed up.