### PR TITLE
[resolves #2397] .editorconfig checks fail on Windows

### DIFF
--- a/catalog/pom.xml
+++ b/catalog/pom.xml
@@ -131,6 +131,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.ec4j.maven</groupId>
+                <artifactId>editorconfig-maven-plugin</artifactId>
+                <configuration>
+                    <excludes combine.children="append">
+                        <exclude>src/main/resources/*.roadmap</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/itests/standalone/basic/pom.xml
+++ b/itests/standalone/basic/pom.xml
@@ -299,6 +299,7 @@
                 <artifactId>editorconfig-maven-plugin</artifactId>
                 <configuration>
                     <excludes combine.children="append">
+                        <exclude>.toDelete</exclude><!-- created by Cassandra maybe? -->
                         <exclude>derby.log</exclude>
                         <exclude>**/lumberjack/window*</exclude>
                         <exclude>**/asn1/*.tt</exclude>

--- a/itests/standalone/extra/pom.xml
+++ b/itests/standalone/extra/pom.xml
@@ -211,6 +211,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.ec4j.maven</groupId>
+                <artifactId>editorconfig-maven-plugin</artifactId>
+                <configuration>
+                    <excludes combine.children="append">
+                        <exclude>src/test/resources/classloading/exported-paths.txt</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This passed the Windows job: https://fusesource-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/wildfly-camel/job/wildfly-camel-master-windows-editorconfig-test/5/console