### PR TITLE
[WFCORE-3527] Refactoring - OSGi constants have been removed from WF

### DIFF
--- a/subsystem/core/src/main/java/org/wildfly/extension/camel/parser/CamelSubsystemAdd.java
+++ b/subsystem/core/src/main/java/org/wildfly/extension/camel/parser/CamelSubsystemAdd.java
@@ -58,7 +58,7 @@ public final class CamelSubsystemAdd extends AbstractBoottimeAddStepHandler {
     public static final int DEPENDENCIES_CAMEL_INTEGRATION = Phase.DEPENDENCIES_LOGGING + 0x01;
     public static final int DEPENDENCIES_CAMEL_WIRINGS = DEPENDENCIES_CAMEL_INTEGRATION + 0x01;
 
-    public static final int INSTALL_PACKAGE_SCAN_RESOLVER = Phase.INSTALL_BUNDLE_ACTIVATE + 0x01;
+    public static final int INSTALL_PACKAGE_SCAN_RESOLVER = Phase.INSTALL_MDB_DELIVERY_DEPENDENCIES + 0x09;
     public static final int INSTALL_CDI_BEAN_ARCHIVE_PROCESSOR = INSTALL_PACKAGE_SCAN_RESOLVER + 0x01;
     public static final int INSTALL_CAMEL_CONTEXT_CREATE = INSTALL_CDI_BEAN_ARCHIVE_PROCESSOR +0x01;
     public static final int INSTALL_CONTEXT_ACTIVATION = INSTALL_CAMEL_CONTEXT_CREATE + 0x01;


### PR DESCRIPTION
See https://github.com/wildfly/wildfly-core/pull/3050 for more information.