### PR TITLE
[revert #2497] Camel subsystem not activated by @ImportResource in EAR

### DIFF
--- a/itests/standalone/basic/src/test/java/org/wildfly/camel/test/classloading/CamelEnablementImportResourceWarInEarTest.java
+++ b/itests/standalone/basic/src/test/java/org/wildfly/camel/test/classloading/CamelEnablementImportResourceWarInEarTest.java
@@ -30,6 +30,7 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.camel.test.classloading.subC.XmlRouteBuilder;
@@ -38,6 +39,7 @@ import org.wildfly.extension.camel.CamelContextRegistry;
 
 @CamelAware
 @RunWith(Arquillian.class)
+@Ignore("[#2497] Camel subsystem not activated by @ImportResource in EAR")
 public class CamelEnablementImportResourceWarInEarTest {
 
     @ArquillianResource

--- a/subsystem/core/src/main/java/org/wildfly/extension/camel/deployment/CamelContextDescriptorsProcessor.java
+++ b/subsystem/core/src/main/java/org/wildfly/extension/camel/deployment/CamelContextDescriptorsProcessor.java
@@ -54,7 +54,7 @@ public class CamelContextDescriptorsProcessor implements DeploymentUnitProcessor
         final String runtimeName = depUnit.getName();
 
         CamelDeploymentSettings depSettings = depUnit.getAttachment(CamelDeploymentSettings.ATTACHMENT_KEY);
-        if (depSettings.isDisabledByJbossAll() || !depSettings.isDeploymentValid() || depUnit.getParent() != null) {
+        if (depSettings.isDisabledByJbossAll() || !depSettings.isDeploymentValid() || runtimeName.endsWith(".ear")) {
             return;
         }
 


### PR DESCRIPTION
This reverts commit 25baab943315d38fd9e757b45b8ffe74ae8adf8a.