### PR TITLE
[resolves #2622] WildFly server reload leads to multiple CamelContext…

### DIFF
--- a/itests/standalone/smoke/src/test/java/org/wildfly/camel/test/smoke/ContextTrackerRegistryTest.java
+++ b/itests/standalone/smoke/src/test/java/org/wildfly/camel/test/smoke/ContextTrackerRegistryTest.java
@@ -1,0 +1,99 @@
+/*
+ * #%L
+ * Wildfly Camel :: Testsuite
+ * %%
+ * Copyright (C) 2013 - 2018 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wildfly.camel.test.smoke;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.CamelContextTrackerRegistry;
+import org.apache.camel.spi.CamelContextTracker;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.camel.test.common.http.HttpRequest;
+import org.wildfly.camel.test.common.utils.EnvironmentUtils;
+import org.wildfly.extension.camel.CamelAware;
+
+/**
+ * Verifies that there is only ever 1 CamelContextTracker registered
+ */
+@RunAsClient
+@RunWith(Arquillian.class)
+public class ContextTrackerRegistryTest {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, "camel-management-strategy-tests.jar")
+            .addClass(TrackerCountReportingRouteBuilder.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testRegisteredContextTrackerCount() throws Exception {
+        String responseA = HttpRequest.get("http://localhost:8080/trackerCount").getResponse().getBody();
+        Assert.assertEquals("1", responseA);
+
+        reloadAppServer();
+
+        String responseB = HttpRequest.get("http://localhost:8080/trackerCount").getResponse().getBody();
+        Assert.assertEquals("1", responseB);
+    }
+
+    private void reloadAppServer() throws IOException, InterruptedException {
+        String jbossHome = System.getProperty("jboss.home.dir");
+        String extension = EnvironmentUtils.isWindows() ? ".bat" : ".sh";
+        new ProcessBuilder()
+            .command(jbossHome + "/bin/jboss-cli" + extension, "-c", "--command=reload")
+            .start()
+            .waitFor();
+    }
+
+    @ApplicationScoped
+    @CamelAware
+    static class TrackerCountReportingRouteBuilder  extends RouteBuilder {
+        @Override
+        public void configure() throws Exception {
+            from("undertow:http://localhost:8080/trackerCount")
+                .process(new Processor() {
+                    @Override
+                    public void process(Exchange exchange) throws Exception {
+                        Field field = CamelContextTrackerRegistry.class.getDeclaredField("trackers");
+                        field.setAccessible(true);
+                        Set<CamelContextTracker> trackers = (Set<CamelContextTracker>) field.get(CamelContextTrackerRegistry.INSTANCE);
+                        exchange.getOut().setBody(String.valueOf(trackers.size()));
+                        field.setAccessible(false);
+                    }
+                });
+        }
+    }
+
+}

--- a/subsystem/core/src/main/java/org/wildfly/extension/camel/service/CamelContextRegistryService.java
+++ b/subsystem/core/src/main/java/org/wildfly/extension/camel/service/CamelContextRegistryService.java
@@ -44,7 +44,6 @@ import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.AbstractService;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
@@ -107,8 +106,7 @@ public class CamelContextRegistryService extends AbstractService<MutableCamelCon
     @Override
     public void start(StartContext startContext) throws StartException {
         ContextCreateHandlerRegistry handlerRegistry = injectedHandlerRegistry.getValue();
-        ServiceRegistry serviceRegistry = startContext.getController().getServiceContainer();
-        contextRegistry = new CamelContextRegistryImpl(handlerRegistry, serviceRegistry, startContext.getChildTarget());
+        contextRegistry = new CamelContextRegistryImpl(handlerRegistry, startContext.getChildTarget());
 
         // Register the service with gravia
         Runtime runtime = injectedRuntime.getValue();
@@ -131,6 +129,10 @@ public class CamelContextRegistryService extends AbstractService<MutableCamelCon
             } catch (Exception e) {
                 LOGGER.warn("Cannot stop camel context: " + name, e);
             }
+        }
+
+        if (contextRegistry != null) {
+            CamelContextTrackerRegistry.INSTANCE.removeTracker((CamelContextTracker) contextRegistry);
         }
 
         if (registration != null) {
@@ -170,7 +172,7 @@ public class CamelContextRegistryService extends AbstractService<MutableCamelCon
         private final ContextCreateHandlerRegistry handlerRegistry;
         private final ServiceTarget serviceTarget;
 
-        CamelContextRegistryImpl(ContextCreateHandlerRegistry handlerRegistry, ServiceRegistry serviceRegistry, ServiceTarget serviceTarget) {
+        CamelContextRegistryImpl(ContextCreateHandlerRegistry handlerRegistry, ServiceTarget serviceTarget) {
             this.handlerRegistry = handlerRegistry;
             this.serviceTarget = serviceTarget;
             CamelContextTrackerRegistry.INSTANCE.addTracker(this);


### PR DESCRIPTION
…Registry instances in CamelContextTrackerRegistry