### PR TITLE
[Fix #2686] Make the usage of EnvironmentUtils.getWildFlyHome() avoid…

### DIFF
--- a/itests/common/src/main/java/org/wildfly/camel/test/common/utils/UserManager.java
+++ b/itests/common/src/main/java/org/wildfly/camel/test/common/utils/UserManager.java
@@ -81,26 +81,54 @@ public final class UserManager implements Closeable {
     }
 
     /**
+     * `$jbossHome` taken from {@link EnvironmentUtils#getWildFlyHome()}.
+     *
      * @return a new {@link UserManager} that will operate on
      *         {@code $jbossHome/standalone/configuration/application-users.properties} and
      *         {@code $jbossHome/standalone/configuration/application-roles.properties}
      * @throws IOException
      */
     public static UserManager forStandaloneApplicationRealm() throws IOException {
-        final Path jbossHome = EnvironmentUtils.getWildFlyHome();
+        return forStandaloneApplicationRealm(EnvironmentUtils.getWildFlyHome());
+    }
+
+    /**
+     * @param jbossHome relative to where {@code application-users.properties} and {@code application-roles.properties}
+     *        should be resolved
+     * @return a new {@link UserManager} that will operate on
+     *         {@code $jbossHome/standalone/configuration/application-users.properties} and
+     *         {@code $jbossHome/standalone/configuration/application-roles.properties}
+     * @throws IOException
+     */
+    public static UserManager forStandaloneApplicationRealm(Path jbossHome) throws IOException {
         final Path userPropertiesPath = jbossHome.resolve("standalone/configuration/application-users.properties");
         final Path rolePropertiesPath = jbossHome.resolve("standalone/configuration/application-roles.properties");
         return new UserManager(userPropertiesPath, rolePropertiesPath, APPLICATION_REALM);
     }
 
+
     /**
+     * `$jbossHome` taken from {@link EnvironmentUtils#getWildFlyHome()}.
+     *
      * @return a new {@link UserManager} that will operate on
      *         {@code $jbossHome/standalone/configuration/mgmt-users.properties} and
      *         {@code $jbossHome/standalone/configuration/mgmt-roles.properties}
      * @throws IOException
      */
     public static UserManager forStandaloneManagementRealm() throws IOException {
-        final Path jbossHome = EnvironmentUtils.getWildFlyHome();
+        return forStandaloneManagementRealm(EnvironmentUtils.getWildFlyHome());
+    }
+
+
+    /**
+     * @param jbossHome relative to where {@code mgmt-users.properties} and {@code mgmt-roles.properties} should be
+     *        resolved
+     * @return a new {@link UserManager} that will operate on
+     *         {@code $jbossHome/standalone/configuration/mgmt-users.properties} and
+     *         {@code $jbossHome/standalone/configuration/mgmt-roles.properties}
+     * @throws IOException
+     */
+    public static UserManager forStandaloneManagementRealm(Path jbossHome) throws IOException {
         final Path userPropertiesPath = jbossHome.resolve("standalone/configuration/mgmt-users.properties");
         final Path rolePropertiesPath = jbossHome.resolve("standalone/configuration/mgmt-roles.properties");
         return new UserManager(userPropertiesPath, rolePropertiesPath, MANAGEMENT_REALM);

--- a/itests/common/src/main/java/org/wildfly/camel/test/common/utils/WildFlyCli.java
+++ b/itests/common/src/main/java/org/wildfly/camel/test/common/utils/WildFlyCli.java
@@ -38,8 +38,15 @@ import java.util.List;
 public class WildFlyCli {
     private static final String DEFAULT_TIMEOUT = "60000";
 
-    private WildFlyCli() {
-        // Hide ctor
+    private final Path wildFlyHome;
+
+    public WildFlyCli(Path wildFlyHome) {
+        super();
+        this.wildFlyHome = wildFlyHome;
+    }
+
+    public WildFlyCli() {
+        this(EnvironmentUtils.getWildFlyHome());
     }
 
     /**
@@ -52,10 +59,10 @@ public class WildFlyCli {
      * @throws IOException
      * @throws InterruptedException
      */
-    public static WildFlyCliResult run(Path cliScript, String... cliArgs) throws IOException, InterruptedException {
+    public WildFlyCliResult run(Path cliScript, String... cliArgs) throws IOException, InterruptedException {
         final ProcessBuilder pb = new ProcessBuilder();
         final String ext = EnvironmentUtils.isWindows() ? "bat" : "sh";
-        final String jbossCliPath = EnvironmentUtils.getWildFlyHome().resolve("bin/jboss-cli." + ext).normalize().toString();
+        final String jbossCliPath = wildFlyHome.resolve("bin/jboss-cli." + ext).normalize().toString();
         final List<String> command = new ArrayList<>();
         command.add(jbossCliPath);
         command.add("--connect");
@@ -91,7 +98,7 @@ public class WildFlyCli {
      * @throws IOException
      * @throws InterruptedException
      */
-    public static WildFlyCliResult run(String cliScript, String... cliArgs) throws IOException, InterruptedException {
+    public WildFlyCliResult run(String cliScript, String... cliArgs) throws IOException, InterruptedException {
         Path path = Files.createTempFile(WildFlyCli.class.getSimpleName(), ".cli");
         Files.write(path, cliScript.getBytes(StandardCharsets.UTF_8));
         return run(path, cliArgs);
@@ -106,7 +113,7 @@ public class WildFlyCli {
      * @throws IOException
      * @throws InterruptedException
      */
-    public static WildFlyCliResult run(URL cliScript, String... cliArgs) throws IOException, InterruptedException {
+    public WildFlyCliResult run(URL cliScript, String... cliArgs) throws IOException, InterruptedException {
         Path path = Files.createTempFile(WildFlyCli.class.getSimpleName(), ".cli");
         FileUtils.copy(cliScript, path);
         return run(path, cliArgs);

--- a/itests/standalone/basic/src/test/java/org/wildfly/camel/test/common/security/ClientCertSecurityDomainSetup.java
+++ b/itests/standalone/basic/src/test/java/org/wildfly/camel/test/common/security/ClientCertSecurityDomainSetup.java
@@ -29,7 +29,7 @@ public class ClientCertSecurityDomainSetup implements ServerSetupTask {
             um.addRole(CLIENT_ALIAS, APPLICATION_ROLE);
         }
         URL cliUrl = this.getClass().getClassLoader().getResource("security/cli/client-cert/setup.cli");
-        WildFlyCli.run(cliUrl).assertSuccess();
+        new WildFlyCli().run(cliUrl).assertSuccess();
     }
 
     @Override
@@ -38,6 +38,6 @@ public class ClientCertSecurityDomainSetup implements ServerSetupTask {
             um.removeRole(CLIENT_ALIAS, APPLICATION_ROLE);
         }
         URL cliUrl = this.getClass().getClassLoader().getResource("security/cli/client-cert/tear-down.cli");
-        WildFlyCli.run(cliUrl).assertSuccess();
+        new WildFlyCli().run(cliUrl).assertSuccess();
     }
 }

--- a/itests/standalone/basic/src/test/java/org/wildfly/camel/test/stomp/StompIntegrationTest.java
+++ b/itests/standalone/basic/src/test/java/org/wildfly/camel/test/stomp/StompIntegrationTest.java
@@ -68,7 +68,7 @@ public class StompIntegrationTest {
                 + "params={protocols=STOMP, port=" + STOMP_PORT + "})\n"
                 + "reload";
 
-            WildFlyCli.run(cliScript).assertSuccess();
+            new WildFlyCli().run(cliScript).assertSuccess();
 
             try (UserManager userManager = UserManager.forStandaloneApplicationRealm()) {
                 userManager.addUser(USERNAME, PASSWORD);
@@ -80,7 +80,7 @@ public class StompIntegrationTest {
         public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
             String cliScript = "/subsystem=messaging-activemq/server=default/acceptor=stomp-acceptor:remove\n"
                 + "reload";
-            WildFlyCli.run(cliScript).assertSuccess();
+            new WildFlyCli().run(cliScript).assertSuccess();
 
             try (UserManager userManager = UserManager.forStandaloneApplicationRealm()) {
                 userManager.removeUser(USERNAME);

--- a/itests/standalone/smoke/src/test/java/org/wildfly/camel/test/smoke/ContextTrackerRegistryTest.java
+++ b/itests/standalone/smoke/src/test/java/org/wildfly/camel/test/smoke/ContextTrackerRegistryTest.java
@@ -69,7 +69,7 @@ public class ContextTrackerRegistryTest {
     }
 
     private void reloadAppServer() throws IOException, InterruptedException {
-        WildFlyCli.run("reload").assertSuccess();
+        new WildFlyCli().run("reload").assertSuccess();
     }
 
     @ApplicationScoped


### PR DESCRIPTION
…able in UserManager and WildFlyCli

An attempt to make the two classes flexible again.