### PR TITLE
update galleon package spec namespace from 1.0 to 2.0

### DIFF
--- a/feature/modules/src/main/resources/packages/hawtio-wildfly.war/package.xml
+++ b/feature/modules/src/main/resources/packages/hawtio-wildfly.war/package.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="hawtio-wildfly.war">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="hawtio-wildfly.war">
 </package-spec>

--- a/feature/pack/src/main/resources/packages/layers.conf/package.xml
+++ b/feature/pack/src/main/resources/packages/layers.conf/package.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="layers.conf">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="layers.conf">
 </package-spec>

--- a/feature/pack/src/main/resources/packages/product.conf/package.xml
+++ b/feature/pack/src/main/resources/packages/product.conf/package.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="product.conf">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="product.conf">
 </package-spec>


### PR DESCRIPTION
Just to keep up with the latest namespace (it's actually been there since Galleon 2).