### PR TITLE
[ENTESB-21851] Support Elytron in Wildfly Camel security

### DIFF
--- a/subsystem/security/src/main/java/org/wildfly/extension/camel/security/ElytronAuthorizationPolicy.java
+++ b/subsystem/security/src/main/java/org/wildfly/extension/camel/security/ElytronAuthorizationPolicy.java
@@ -1,0 +1,132 @@
+/*
+ * #%L
+ * Wildfly Camel :: Subsystem
+ * %%
+ * Copyright (C) 2013 - 2014 RedHat
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package org.wildfly.extension.camel.security;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.NamedNode;
+import org.apache.camel.Processor;
+import org.apache.camel.Route;
+import org.apache.camel.spi.AuthorizationPolicy;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.authz.Roles;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginException;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Authorization policy compatible with Elytron security. Checks if current user has required roles in order to be able
+ * to run a Camel route. Alternatively, one can use a specific user instead of the currently logged one.
+ */
+public class ElytronAuthorizationPolicy implements AuthorizationPolicy {
+
+    private Set<String> requiredRoles;
+
+
+    public ElytronAuthorizationPolicy() {
+        requiredRoles = new HashSet<>();
+    }
+
+
+    public ElytronAuthorizationPolicy roles(String... roles) {
+        requiredRoles.addAll(Arrays.asList(roles));
+        return this;
+    }
+
+    // for use in spring xml
+    public void setRole(String role) {
+        requiredRoles.add(role);
+    }
+
+    @Override
+    public void beforeWrap(Route route, NamedNode definition) {
+        // no code
+    }
+
+    @Override
+    public Processor wrap(Route route, Processor processor) {
+        return new Processor() {
+            @Override
+            public void process(Exchange exchange) throws Exception {
+                SecurityDomain securityDomain = SecurityDomain.getCurrent();
+                SecurityIdentity securityIdentity;
+
+                Subject subject = exchange.getIn().getHeader(Exchange.AUTHENTICATION, Subject.class);
+                if (subject == null) {
+                    // use currently logged user
+                    securityIdentity = securityDomain.getCurrentSecurityIdentity();
+                } else {
+                    // use user specified in the exchange
+                    UsernamePasswordPrincipal credentials = getCredentials(subject);
+                    String username = credentials.getName();
+                    char[] password = credentials.getPassword();
+                    securityIdentity = securityDomain.authenticate(username, new PasswordGuessEvidence(password));
+                }
+
+                checkRequiredRoles(securityIdentity.getRoles());
+                processor.process(exchange);
+            }
+        };
+    }
+
+    private UsernamePasswordPrincipal getCredentials(Subject subject) {
+        String username = null;
+        char[] password = null;
+        for (Principal principal : subject.getPrincipals()) {
+            if (principal instanceof UsernamePasswordPrincipal) {
+                UsernamePasswordPrincipal p = (UsernamePasswordPrincipal) principal;
+                username = p.getName();
+                password = p.getPassword();
+                break;
+            }
+            if (principal instanceof UsernamePasswordAuthenticationToken) {
+                UsernamePasswordAuthenticationToken p = (UsernamePasswordAuthenticationToken) principal;
+                username = p.getName();
+                Object credentials = p.getCredentials();
+                if (credentials instanceof String) {
+                    password = ((String) credentials).toCharArray();
+                } else if (credentials instanceof char[]) {
+                    password = (char[]) credentials;
+                }
+                break;
+            }
+        }
+        if (username == null || password == null) {
+            throw new SecurityException("Cannot obtain credentials from exchange");
+        }
+        return new UsernamePasswordPrincipal(username, password);
+    }
+
+    private void checkRequiredRoles(Roles roles) throws LoginException {
+        for (String role : requiredRoles) {
+            if (!roles.contains(role)) {
+                throw new LoginException("User does not have required roles: " + role);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-21851

DomainAuthenticationPolicy doesn't work with Elytron (it doesn't even work with JDK 17). I've added a ElytronAuthorizationPolicy that is an alternative that mimics DomainAuthenticationPolicy as much as possible.

1. If client code provides UsernamePasswordPrincipal just as before, it will authenticate the provided user and checks his roles
2. If no UsernamePasswordPrincipal is provided, it will check currently logged user. This is a new feature that I believe will be very helpful since it doesn't need a password to be provided in a plain text (security leak!). Legacy Wildfly security wasn't able to provide currently logged user, but Elytron is able to do so.
3. Domains (DomainPrincipal) are no longer taken into account since Elytron doesn't use named ones.